### PR TITLE
feat: add auth api foundation

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,10 +8,10 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 from app.config import settings
-from app.models.base import Base
 
 # Import models to register them with Base.metadata for autogenerate support
 from app.models import Project, User  # noqa: F401
+from app.models.base import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,91 @@
+"""API dependencies for authentication and authorization."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.redis import is_token_blacklisted
+from app.core.security import decode_token
+from app.models.user import User
+from app.repositories.user import UserRepository
+
+# HTTP Bearer security scheme
+security = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> User:
+    """Get the current authenticated user from JWT token.
+
+    Args:
+        credentials: HTTP Bearer credentials containing the JWT token.
+        db: Database session.
+
+    Returns:
+        The authenticated user.
+
+    Raises:
+        HTTPException: If token is invalid, expired, or user not found.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    token = credentials.credentials
+
+    # Check if token is blacklisted
+    if await is_token_blacklisted(token):
+        raise credentials_exception
+
+    # Decode and validate token
+    payload = decode_token(token)
+    if payload is None:
+        raise credentials_exception
+
+    # Ensure it's an access token
+    if payload.type != "access":
+        raise credentials_exception
+
+    # Get user from database
+    try:
+        user_id = UUID(payload.sub)
+    except ValueError:
+        raise credentials_exception from None
+
+    user_repo = UserRepository(db)
+    user = await user_repo.get_by_id(user_id)
+
+    if user is None:
+        raise credentials_exception
+
+    return user
+
+
+async def get_current_active_user(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Get the current active user.
+
+    Args:
+        current_user: The authenticated user.
+
+    Returns:
+        The active user.
+
+    Raises:
+        HTTPException: If user is inactive.
+    """
+    if not current_user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Inactive user",
+        )
+    return current_user

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -1,0 +1,232 @@
+"""Authentication endpoints."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_active_user
+from app.core.database import get_db
+from app.core.redis import add_token_to_blacklist, is_token_blacklisted
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+from app.models.user import User
+from app.repositories.user import UserRepository
+from app.schemas.auth import (
+    LoginRequest,
+    RefreshTokenRequest,
+    RegisterRequest,
+    TokenResponse,
+)
+from app.schemas.user import UserRead
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+security = HTTPBearer()
+
+
+@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+async def register(
+    request: RegisterRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TokenResponse:
+    """Register a new user.
+
+    Args:
+        request: Registration request containing email, name, and password.
+        db: Database session.
+
+    Returns:
+        Access and refresh tokens.
+
+    Raises:
+        HTTPException: If email is already registered.
+    """
+    user_repo = UserRepository(db)
+
+    # Check if email already exists
+    if await user_repo.email_exists(request.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    # Create user with hashed password
+    hashed_password = hash_password(request.password)
+    user = await user_repo.create(
+        email=request.email,
+        name=request.name,
+        password_hash=hashed_password,
+        auth_provider="local",
+    )
+
+    # Generate tokens
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    request: LoginRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TokenResponse:
+    """Login with email and password.
+
+    Args:
+        request: Login request containing email and password.
+        db: Database session.
+
+    Returns:
+        Access and refresh tokens.
+
+    Raises:
+        HTTPException: If credentials are invalid.
+    """
+    user_repo = UserRepository(db)
+
+    # Get user by email
+    user = await user_repo.get_by_email(request.email)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+
+    # Verify password
+    if user.password_hash is None or not verify_password(
+        request.password, user.password_hash
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+
+    # Check if user is active
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    # Generate tokens
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> None:
+    """Logout and invalidate the current access token.
+
+    Args:
+        credentials: HTTP Bearer credentials containing the JWT token.
+    """
+    token = credentials.credentials
+
+    # Decode token to get expiration time
+    payload = decode_token(token)
+    if payload is not None:
+        # Calculate remaining time until expiration
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        if payload.exp > now:
+            expires_in = payload.exp - now
+            await add_token_to_blacklist(token, expires_in)
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(
+    request: RefreshTokenRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TokenResponse:
+    """Refresh access token using a refresh token.
+
+    Args:
+        request: Refresh token request.
+        db: Database session.
+
+    Returns:
+        New access and refresh tokens.
+
+    Raises:
+        HTTPException: If refresh token is invalid.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid refresh token",
+    )
+
+    # Check if token is blacklisted
+    if await is_token_blacklisted(request.refresh_token):
+        raise credentials_exception
+
+    # Decode refresh token
+    payload = decode_token(request.refresh_token)
+    if payload is None:
+        raise credentials_exception
+
+    # Ensure it's a refresh token
+    if payload.type != "refresh":
+        raise credentials_exception
+
+    # Get user from database
+    try:
+        user_id = UUID(payload.sub)
+    except ValueError:
+        raise credentials_exception from None
+
+    user_repo = UserRepository(db)
+    user = await user_repo.get_by_id(user_id)
+
+    if user is None or not user.is_active:
+        raise credentials_exception
+
+    # Blacklist old refresh token
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    if payload.exp > now:
+        expires_in = payload.exp - now
+        await add_token_to_blacklist(request.refresh_token, expires_in)
+
+    # Generate new tokens
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+@router.get("/me", response_model=UserRead)
+async def get_current_user_info(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+) -> User:
+    """Get current user information.
+
+    Args:
+        current_user: The authenticated user.
+
+    Returns:
+        User information.
+    """
+    return current_user

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,9 +2,12 @@
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import health
+from app.api.v1.endpoints import auth, health
 
 api_router = APIRouter()
 
 # Include health endpoint
 api_router.include_router(health.router, tags=["health"])
+
+# Include auth endpoints
+api_router.include_router(auth.router)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,5 +24,11 @@ class Settings(BaseSettings):
     # Redis
     redis_url: str = "redis://localhost:6379"
 
+    # JWT
+    jwt_secret_key: str = "your-secret-key-change-in-production"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
+    refresh_token_expire_days: int = 7
+
 
 settings = Settings()

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -1,0 +1,64 @@
+"""Redis client for token blacklist management."""
+
+from datetime import timedelta
+
+import redis.asyncio as redis
+
+from app.config import settings
+
+# Redis client instance
+redis_client: redis.Redis | None = None
+
+# Key prefix for token blacklist
+BLACKLIST_PREFIX = "token_blacklist:"
+
+
+async def get_redis() -> redis.Redis:
+    """Get or create Redis client.
+
+    Returns:
+        Redis client instance.
+    """
+    global redis_client
+    if redis_client is None:
+        redis_client = redis.from_url(
+            settings.redis_url,
+            encoding="utf-8",
+            decode_responses=True,
+        )
+    return redis_client
+
+
+async def close_redis() -> None:
+    """Close Redis connection."""
+    global redis_client
+    if redis_client is not None:
+        await redis_client.close()
+        redis_client = None
+
+
+async def add_token_to_blacklist(token: str, expires_in: timedelta) -> None:
+    """Add a token to the blacklist.
+
+    Args:
+        token: The JWT token to blacklist.
+        expires_in: How long to keep the token in the blacklist.
+    """
+    client = await get_redis()
+    key = f"{BLACKLIST_PREFIX}{token}"
+    await client.setex(key, expires_in, "blacklisted")
+
+
+async def is_token_blacklisted(token: str) -> bool:
+    """Check if a token is blacklisted.
+
+    Args:
+        token: The JWT token to check.
+
+    Returns:
+        True if token is blacklisted, False otherwise.
+    """
+    client = await get_redis()
+    key = f"{BLACKLIST_PREFIX}{token}"
+    result = await client.get(key)
+    return result is not None

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,129 @@
+"""Security utilities for password hashing and JWT handling."""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import bcrypt
+from jose import JWTError, jwt
+
+from app.config import settings
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using bcrypt.
+
+    Args:
+        password: Plain text password.
+
+    Returns:
+        Hashed password string.
+    """
+    salt = bcrypt.gensalt()
+    hashed = bcrypt.hashpw(password.encode("utf-8"), salt)
+    return hashed.decode("utf-8")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against its hash.
+
+    Args:
+        plain_password: Plain text password to verify.
+        hashed_password: Hashed password to compare against.
+
+    Returns:
+        True if password matches, False otherwise.
+    """
+    return bcrypt.checkpw(
+        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+    )
+
+
+def create_access_token(user_id: UUID, expires_delta: timedelta | None = None) -> str:
+    """Create a JWT access token.
+
+    Args:
+        user_id: The user's UUID.
+        expires_delta: Optional custom expiration time.
+
+    Returns:
+        Encoded JWT string.
+    """
+    if expires_delta:
+        expire = datetime.now(UTC) + expires_delta
+    else:
+        expire = datetime.now(UTC) + timedelta(
+            minutes=settings.access_token_expire_minutes
+        )
+
+    to_encode = {
+        "sub": str(user_id),
+        "exp": expire,
+        "type": "access",
+    }
+    return jwt.encode(
+        to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )
+
+
+def create_refresh_token(user_id: UUID, expires_delta: timedelta | None = None) -> str:
+    """Create a JWT refresh token.
+
+    Args:
+        user_id: The user's UUID.
+        expires_delta: Optional custom expiration time.
+
+    Returns:
+        Encoded JWT string.
+    """
+    if expires_delta:
+        expire = datetime.now(UTC) + expires_delta
+    else:
+        expire = datetime.now(UTC) + timedelta(days=settings.refresh_token_expire_days)
+
+    to_encode = {
+        "sub": str(user_id),
+        "exp": expire,
+        "type": "refresh",
+    }
+    return jwt.encode(
+        to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )
+
+
+class TokenPayload:
+    """Decoded token payload."""
+
+    def __init__(self, sub: str, exp: datetime, token_type: str) -> None:
+        """Initialize token payload."""
+        self.sub = sub
+        self.exp = exp
+        self.type = token_type
+
+
+def decode_token(token: str) -> TokenPayload | None:
+    """Decode and validate a JWT token.
+
+    Args:
+        token: The JWT token string.
+
+    Returns:
+        TokenPayload if valid, None otherwise.
+    """
+    try:
+        payload = jwt.decode(
+            token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]
+        )
+        sub: str | None = payload.get("sub")
+        exp: int | None = payload.get("exp")
+        token_type: str | None = payload.get("type")
+
+        if sub is None or exp is None or token_type is None:
+            return None
+
+        return TokenPayload(
+            sub=sub,
+            exp=datetime.fromtimestamp(exp, tz=UTC),
+            token_type=token_type,
+        )
+    except JWTError:
+        return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,14 +7,17 @@ from fastapi import FastAPI
 
 from app.api.v1.router import api_router
 from app.config import settings
+from app.core.redis import close_redis, get_redis
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan handler for startup and shutdown events."""
     # Startup
+    await get_redis()
     yield
     # Shutdown
+    await close_redis()
 
 
 def create_app() -> FastAPI:

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -1,0 +1,83 @@
+"""User repository for database operations."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+
+class UserRepository:
+    """Repository for user-related database operations."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        """Initialize the repository with a database session."""
+        self.db = db
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Get a user by email address.
+
+        Args:
+            email: The email address to search for.
+
+        Returns:
+            The user if found, None otherwise.
+        """
+        stmt = select(User).where(User.email == email)
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_by_id(self, user_id: UUID) -> User | None:
+        """Get a user by ID.
+
+        Args:
+            user_id: The UUID of the user.
+
+        Returns:
+            The user if found, None otherwise.
+        """
+        stmt = select(User).where(User.id == user_id)
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        email: str,
+        name: str,
+        password_hash: str,
+        auth_provider: str = "local",
+    ) -> User:
+        """Create a new user.
+
+        Args:
+            email: User's email address.
+            name: User's display name.
+            password_hash: Hashed password.
+            auth_provider: Authentication provider (default: "local").
+
+        Returns:
+            The created user.
+        """
+        user = User(
+            email=email,
+            name=name,
+            password_hash=password_hash,
+            auth_provider=auth_provider,
+        )
+        self.db.add(user)
+        await self.db.commit()
+        await self.db.refresh(user)
+        return user
+
+    async def email_exists(self, email: str) -> bool:
+        """Check if an email address is already registered.
+
+        Args:
+            email: The email address to check.
+
+        Returns:
+            True if email exists, False otherwise.
+        """
+        user = await self.get_by_email(email)
+        return user is not None

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,63 @@
+"""Authentication Pydantic schemas."""
+
+import re
+
+from pydantic import BaseModel, EmailStr, field_validator
+
+
+class LoginRequest(BaseModel):
+    """Schema for login request."""
+
+    email: EmailStr
+    password: str
+
+
+class RegisterRequest(BaseModel):
+    """Schema for user registration request."""
+
+    email: EmailStr
+    name: str
+    password: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate name is not empty and has reasonable length."""
+        v = v.strip()
+        if not v:
+            raise ValueError("Name cannot be empty")
+        if len(v) > 100:
+            raise ValueError("Name must be 100 characters or less")
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        """Validate password strength.
+
+        Requirements:
+        - Minimum 8 characters
+        - At least one letter
+        - At least one number
+        """
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        if not re.search(r"[a-zA-Z]", v):
+            raise ValueError("Password must contain at least one letter")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one number")
+        return v
+
+
+class TokenResponse(BaseModel):
+    """Schema for token response."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class RefreshTokenRequest(BaseModel):
+    """Schema for token refresh request."""
+
+    refresh_token: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,9 +9,11 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "asyncpg>=0.30.0",
     "alembic>=1.14.0",
-    "pydantic>=2.10.0",
+    "pydantic[email]>=2.10.0",
     "pydantic-settings>=2.7.0",
     "redis>=5.2.0",
+    "python-jose[cryptography]>=3.3.0",
+    "bcrypt>=4.0.0",
 ]
 
 [project.optional-dependencies]
@@ -20,7 +22,12 @@ dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.25.0",
     "httpx>=0.28.0",
+    "aiosqlite>=0.20.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Pytest configuration and fixtures."""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.core.database import get_db
+from app.main import app
+from app.models.base import Base
+
+# Test database URL (using SQLite for testing)
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Use asyncio backend for pytest-asyncio."""
+    return "asyncio"
+
+
+@pytest_asyncio.fixture
+async def test_engine():
+    """Create a test database engine."""
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_session(test_engine) -> AsyncGenerator[AsyncSession, None]:
+    """Create a test database session."""
+    async_session_maker = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autocommit=False,
+        autoflush=False,
+    )
+    async with async_session_maker() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def client(test_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    """Create a test HTTP client with overridden dependencies."""
+    # Override the database dependency
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield test_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_user_data() -> dict[str, Any]:
+    """Return test user data."""
+    return {
+        "email": "test@example.com",
+        "name": "Test User",
+        "password": "TestPassword123",
+    }

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,376 @@
+"""Tests for authentication endpoints."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestRegister:
+    """Tests for POST /api/v1/auth/register."""
+
+    async def test_register_success(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test successful user registration."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            response = await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+
+    async def test_register_duplicate_email(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test registration with duplicate email."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            # Register first user
+            await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+
+            # Try to register with same email
+            response = await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+
+        assert response.status_code == 400
+        assert "Email already registered" in response.json()["detail"]
+
+    async def test_register_weak_password(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test registration with weak password."""
+        response = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "test@example.com",
+                "name": "Test User",
+                "password": "weak",  # Too short
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_register_password_no_number(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test registration with password without numbers."""
+        response = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "test@example.com",
+                "name": "Test User",
+                "password": "noNumbersHere",
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_register_password_no_letters(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test registration with password without letters."""
+        response = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "test@example.com",
+                "name": "Test User",
+                "password": "12345678",
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_register_invalid_email(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test registration with invalid email."""
+        response = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "invalid-email",
+                "name": "Test User",
+                "password": "ValidPass123",
+            },
+        )
+
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestLogin:
+    """Tests for POST /api/v1/auth/login."""
+
+    async def test_login_success(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test successful login."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            # Register user first
+            await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+
+            # Login
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={
+                    "email": test_user_data["email"],
+                    "password": test_user_data["password"],
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+
+    async def test_login_wrong_password(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test login with wrong password."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            # Register user first
+            await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+
+            # Login with wrong password
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={
+                    "email": test_user_data["email"],
+                    "password": "WrongPassword123",
+                },
+            )
+
+        assert response.status_code == 401
+        assert "Invalid email or password" in response.json()["detail"]
+
+    async def test_login_nonexistent_user(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test login with nonexistent user."""
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "email": "nonexistent@example.com",
+                "password": "SomePassword123",
+            },
+        )
+
+        assert response.status_code == 401
+        assert "Invalid email or password" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+class TestLogout:
+    """Tests for POST /api/v1/auth/logout."""
+
+    async def test_logout_success(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test successful logout."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock) as mock_blacklist:
+            # Register and get token
+            register_response = await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+            access_token = register_response.json()["access_token"]
+
+            # Logout
+            response = await client.post(
+                "/api/v1/auth/logout",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+        assert response.status_code == 204
+        # Verify blacklist was called
+        mock_blacklist.assert_called()
+
+    async def test_logout_without_token(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test logout without token."""
+        response = await client.post("/api/v1/auth/logout")
+
+        # HTTPBearer returns 401 when no credentials are provided
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestRefresh:
+    """Tests for POST /api/v1/auth/refresh."""
+
+    async def test_refresh_success(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test successful token refresh."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            with patch("app.api.v1.endpoints.auth.is_token_blacklisted", new_callable=AsyncMock, return_value=False):
+                # Register and get tokens
+                register_response = await client.post(
+                    "/api/v1/auth/register",
+                    json=test_user_data,
+                )
+                refresh_token = register_response.json()["refresh_token"]
+
+                # Refresh
+                response = await client.post(
+                    "/api/v1/auth/refresh",
+                    json={"refresh_token": refresh_token},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+
+    async def test_refresh_invalid_token(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test refresh with invalid token."""
+        with patch("app.api.v1.endpoints.auth.is_token_blacklisted", new_callable=AsyncMock, return_value=False):
+            response = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "invalid_token"},
+            )
+
+        assert response.status_code == 401
+
+    async def test_refresh_blacklisted_token(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test refresh with blacklisted token."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            # Register and get tokens
+            register_response = await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+            refresh_token = register_response.json()["refresh_token"]
+
+        # Mock blacklisted token
+        with patch("app.api.v1.endpoints.auth.is_token_blacklisted", new_callable=AsyncMock, return_value=True):
+            response = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": refresh_token},
+            )
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUser:
+    """Tests for GET /api/v1/auth/me."""
+
+    async def test_get_current_user_success(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test getting current user info."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            with patch("app.api.deps.is_token_blacklisted", new_callable=AsyncMock, return_value=False):
+                # Register and get token
+                register_response = await client.post(
+                    "/api/v1/auth/register",
+                    json=test_user_data,
+                )
+                access_token = register_response.json()["access_token"]
+
+                # Get current user
+                response = await client.get(
+                    "/api/v1/auth/me",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == test_user_data["email"]
+        assert data["name"] == test_user_data["name"]
+        assert data["auth_provider"] == "local"
+        assert data["is_active"] is True
+
+    async def test_get_current_user_no_token(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test getting current user without token."""
+        response = await client.get("/api/v1/auth/me")
+
+        # HTTPBearer returns 401 when no credentials are provided
+        assert response.status_code == 401
+
+    async def test_get_current_user_invalid_token(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test getting current user with invalid token."""
+        with patch("app.api.deps.is_token_blacklisted", new_callable=AsyncMock, return_value=False):
+            response = await client.get(
+                "/api/v1/auth/me",
+                headers={"Authorization": "Bearer invalid_token"},
+            )
+
+        assert response.status_code == 401
+
+    async def test_get_current_user_blacklisted_token(
+        self,
+        client: AsyncClient,
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test getting current user with blacklisted token."""
+        with patch("app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock):
+            # Register and get token
+            register_response = await client.post(
+                "/api/v1/auth/register",
+                json=test_user_data,
+            )
+            access_token = register_response.json()["access_token"]
+
+        # Mock blacklisted token
+        with patch("app.api.deps.is_token_blacklisted", new_callable=AsyncMock, return_value=True):
+            response = await client.get(
+                "/api/v1/auth/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+        assert response.status_code == 401


### PR DESCRIPTION
## 概要

Issue #13 の認証API基盤を実装しました。メール+パスワードによるローカル認証をサポートし、JWTベースのセッション管理を行います。

## 変更内容

### 新規ファイル

- `app/core/security.py` - パスワードハッシュ（bcrypt）とJWT生成/検証ユーティリティ
- `app/core/redis.py` - トークンブラックリスト管理
- `app/schemas/auth.py` - 認証用リクエスト/レスポンススキーマ
- `app/repositories/user.py` - ユーザーCRUD操作
- `app/api/deps.py` - 認証依存性（`get_current_user`, `get_current_active_user`）
- `app/api/v1/endpoints/auth.py` - 認証エンドポイント
- `tests/conftest.py` - テスト用フィクスチャ
- `tests/test_auth.py` - 認証エンドポイントのユニットテスト

### 更新ファイル

- `pyproject.toml` - 依存関係追加（`python-jose[cryptography]`, `bcrypt`, `pydantic[email]`, `aiosqlite`）
- `app/config.py` - JWT関連設定追加
- `app/api/v1/router.py` - 認証ルーター統合
- `app/main.py` - Redisの接続管理をlifespanに追加

## 実装されたエンドポイント

| メソッド | エンドポイント | 説明 |
|---------|---------------|------|
| POST | `/api/v1/auth/register` | ユーザー新規登録 |
| POST | `/api/v1/auth/login` | ログイン |
| POST | `/api/v1/auth/logout` | ログアウト |
| POST | `/api/v1/auth/refresh` | トークンリフレッシュ |
| GET | `/api/v1/auth/me` | 現在のユーザー情報取得 |

## セキュリティ機能

- ✅ パスワード強度バリデーション（最小8文字、英数字混合必須）
- ✅ bcryptによるパスワードハッシュ化
- ✅ JWT（アクセストークン + リフレッシュトークン）によるステートレス認証
- ✅ Redisによるトークンブラックリスト管理（ログアウト時のトークン無効化）

## テスト

18件のユニットテストを追加し、全てパスしています。

pytest tests/test_auth.py -v
============================== 18 passed in 2.05s ==============================


Closes #13
