### PR TITLE
feat(frontend): Setup NextAuth.js and implement Credentials Provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,11 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=production
+      - AUTH_SECRET=change-this-in-production
+      - AUTH_TRUST_HOST=true
+      - BACKEND_URL=http://backend:8000
     depends_on:
-      - postgres
-      - redis
+      - backend
   backend:
     build:
       context: ./backend

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -1,0 +1,197 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import { z } from "zod";
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export interface BackendTokens {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpires: number;
+}
+
+export interface BackendUser {
+  id: string;
+  email: string;
+  name: string;
+  isAdmin: boolean;
+  isActive: boolean;
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<BackendTokens | null> {
+  try {
+    const response = await fetch(`${process.env.BACKEND_URL}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const tokens = await response.json();
+
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      // Access tokens typically expire in 30 minutes
+      accessTokenExpires: Date.now() + 30 * 60 * 1000,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchUserInfo(accessToken: string): Promise<BackendUser | null> {
+  try {
+    const response = await fetch(`${process.env.BACKEND_URL}/api/v1/auth/me`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const user = await response.json();
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      isAdmin: user.is_admin,
+      isActive: user.is_active,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Credentials({
+      name: "credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const parsed = loginSchema.safeParse(credentials);
+        if (!parsed.success) {
+          return null;
+        }
+
+        const { email, password } = parsed.data;
+
+        try {
+          // Call backend login API
+          const response = await fetch(`${process.env.BACKEND_URL}/api/v1/auth/login`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email, password }),
+          });
+
+          if (!response.ok) {
+            return null;
+          }
+
+          const tokens = await response.json();
+
+          // Fetch user info
+          const user = await fetchUserInfo(tokens.access_token);
+          if (!user) {
+            return null;
+          }
+
+          // Return user with tokens
+          return {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            isAdmin: user.isAdmin,
+            isActive: user.isActive,
+            accessToken: tokens.access_token,
+            refreshToken: tokens.refresh_token,
+            accessTokenExpires: Date.now() + 30 * 60 * 1000,
+          };
+        } catch {
+          return null;
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      // Initial sign in
+      if (user) {
+        return {
+          ...token,
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          isAdmin: user.isAdmin,
+          isActive: user.isActive,
+          accessToken: user.accessToken,
+          refreshToken: user.refreshToken,
+          accessTokenExpires: user.accessTokenExpires,
+        };
+      }
+
+      // Return previous token if access token has not expired
+      if (Date.now() < (token.accessTokenExpires as number)) {
+        return token;
+      }
+
+      // Access token has expired, refresh it
+      const refreshedTokens = await refreshAccessToken(token.refreshToken as string);
+      if (!refreshedTokens) {
+        // Refresh token is invalid, user needs to sign in again
+        return {
+          ...token,
+          error: "RefreshAccessTokenError",
+        };
+      }
+
+      return {
+        ...token,
+        accessToken: refreshedTokens.accessToken,
+        refreshToken: refreshedTokens.refreshToken,
+        accessTokenExpires: refreshedTokens.accessTokenExpires,
+      };
+    },
+    async session({ session, token }) {
+      if (token.error) {
+        // Force sign out on refresh token error
+        session.error = token.error as string;
+      }
+
+      session.user = {
+        ...session.user,
+        id: token.id as string,
+        email: token.email as string,
+        name: token.name as string,
+        isAdmin: token.isAdmin as boolean,
+        isActive: token.isActive as boolean,
+      };
+
+      session.accessToken = token.accessToken as string;
+
+      return session;
+    },
+  },
+  pages: {
+    signIn: "/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,9 +13,11 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "next-auth": "^5.0.0-beta.30",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.5"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -43,6 +45,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1234,6 +1265,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -4485,6 +4525,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5096,6 +5145,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5130,6 +5206,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5418,6 +5503,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -6730,7 +6835,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "next-auth": "^5.0.0-beta.30",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/types/next-auth.d.ts
+++ b/frontend/types/next-auth.d.ts
@@ -1,0 +1,41 @@
+import "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface User {
+    id: string;
+    email: string;
+    name: string;
+    isAdmin: boolean;
+    isActive: boolean;
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpires: number;
+  }
+
+  interface Session {
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      isAdmin: boolean;
+      isActive: boolean;
+    };
+    accessToken: string;
+    error?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id: string;
+    email: string;
+    name: string;
+    isAdmin: boolean;
+    isActive: boolean;
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpires: number;
+    error?: string;
+  }
+}


### PR DESCRIPTION
## 概要

NextAuth.js v5 (Auth.js) を設定し、バックエンドの認証APIと連携するCredentials Providerを実装しました。

## 変更内容

### 新規ファイル
- `frontend/auth.ts` - NextAuth.js のメイン設定ファイル
- `frontend/app/api/auth/[...nextauth]/route.ts` - API ルートハンドラー
- `frontend/types/next-auth.d.ts` - TypeScript 型定義の拡張

### 変更ファイル
- `frontend/package.json` - next-auth@5.0.0-beta.30 と zod を追加
- `docker-compose.yml` - フロントエンドの環境変数を追加

## 実装詳細

### Credentials Provider
- バックエンドの `/api/v1/auth/login` を呼び出してトークンを取得
- ログイン成功後、`/api/v1/auth/me` でユーザー情報を取得

### トークン管理
- アクセストークンとリフレッシュトークンをセッションに保存
- アクセストークンの有効期限切れ時に自動リフレッシュ
- リフレッシュトークンが無効な場合はエラーをセッションに設定

### セッション情報
セッションには以下の情報が含まれます：
- `user.id` - ユーザーID (UUID)
- `user.email` - メールアドレス
- `user.name` - 表示名
- `user.isAdmin` - 管理者フラグ
- `user.isActive` - アクティブフラグ
- `accessToken` - バックエンドAPI呼び出し用トークン

## 環境変数

ローカル開発時は `frontend/.env.local` を作成してください：

```bash
AUTH_SECRET=your-secret-key
AUTH_TRUST_HOST=true
BACKEND_URL=http://localhost:8000
```

## テスト方法

1. バックエンドとフロントエンドを起動
2. `http://localhost:3000/api/auth/providers` にアクセスして Credentials Provider が表示されることを確認
3. `http://localhost:3000/api/auth/signin` でログインフォームが表示されることを確認
4. ログイン後、`http://localhost:3000/api/auth/session` でセッション情報が取得できることを確認

## 受け入れ条件

- [x] NextAuth.jsが正しく設定されている
- [x] Credentials Providerでログインできる
- [x] セッションにユーザー情報とトークンが含まれる
- [x] トークンリフレッシュが動作する

Closes #14