### PR TITLE
feat: implement registration page with form validation (#16)

### DIFF
--- a/frontend/__tests__/components/auth/RegisterForm.test.tsx
+++ b/frontend/__tests__/components/auth/RegisterForm.test.tsx
@@ -1,0 +1,588 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { RegisterForm } from '@/components/auth/RegisterForm';
+
+const mockPush = vi.fn();
+const mockSignIn = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => (key: string) => {
+    const translations: Record<string, Record<string, string>> = {
+      auth: {
+        signUpTitle: 'Sign Up',
+        signUpDescription: 'Create your account',
+        email: 'Email',
+        name: 'Name',
+        password: 'Password',
+        confirmPassword: 'Confirm Password',
+        register: 'Sign up',
+        login: 'Log in',
+        hasAccount: 'Already have an account?',
+        emailRequired: 'Email is required',
+        emailInvalid: 'Please enter a valid email address',
+        nameRequired: 'Name is required',
+        nameTooLong: 'Name must be 100 characters or less',
+        passwordMinLength: 'Password must be at least 8 characters',
+        passwordNeedsLetter: 'Password must contain at least one letter',
+        passwordNeedsNumber: 'Password must contain at least one number',
+        confirmPasswordRequired: 'Please confirm your password',
+        passwordsMustMatch: 'Passwords do not match',
+        emailAlreadyRegistered: 'This email is already registered',
+        registrationFailed: 'Registration failed. Please try again',
+      },
+      common: {
+        loading: 'Loading...',
+      },
+    };
+    return translations[namespace]?.[key] ?? key;
+  },
+}));
+
+vi.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+function getEmailInput() {
+  return screen.getByLabelText('Email');
+}
+
+function getNameInput() {
+  return screen.getByLabelText('Name');
+}
+
+describe('RegisterForm component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('should render the register form', () => {
+    render(<RegisterForm />);
+
+    expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    expect(screen.getByText('Create your account')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Password')).toBeInTheDocument();
+    expect(screen.getByText('Confirm Password')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /sign up/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Already have an account?')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('should have a link to login page', () => {
+    render(<RegisterForm />);
+
+    const loginLink = screen.getByRole('link', { name: /log in/i });
+    expect(loginLink).toHaveAttribute('href', '/login');
+  });
+
+  it('should show validation errors when submitting empty form', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Email is required')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Password must be at least 8 characters')
+      ).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Please confirm your password')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when name is too long', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const nameInput = getNameInput();
+    const longName = 'a'.repeat(101);
+    await user.type(nameInput, longName);
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Name must be 100 characters or less')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when password is too short', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    await user.type(passwordInput, 'short1');
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Password must be at least 8 characters')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when password has no letters', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    await user.type(passwordInput, '12345678');
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Password must contain at least one letter')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when password has no numbers', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    await user.type(passwordInput, 'abcdefgh');
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Password must contain at least one number')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when passwords do not match', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'differentpassword');
+
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    });
+  });
+
+  it('should toggle password visibility', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const toggleButtons = screen.getAllByRole('button', {
+      name: /show password/i,
+    });
+    const passwordToggle = toggleButtons[0];
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    await user.click(passwordToggle);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+
+    await user.click(passwordToggle);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
+  it('should toggle confirm password visibility', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const toggleButtons = screen.getAllByRole('button', {
+      name: /show password/i,
+    });
+    const confirmPasswordToggle = toggleButtons[1];
+
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+    await user.click(confirmPasswordToggle);
+    expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+
+    await user.click(confirmPasswordToggle);
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+  });
+
+  it('should call register API with correct data on submit', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'token',
+        refresh_token: 'refresh',
+        token_type: 'bearer',
+      }),
+    });
+    mockSignIn.mockResolvedValue({ error: null });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'test@example.com',
+          name: 'Test User',
+          password: 'password123',
+        }),
+      });
+    });
+  });
+
+  it('should redirect to home on successful registration and login', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'token',
+        refresh_token: 'refresh',
+        token_type: 'bearer',
+      }),
+    });
+    mockSignIn.mockResolvedValue({ error: null });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith('credentials', {
+        redirect: false,
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('should redirect to login page when auto-login fails after registration', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'token',
+        refresh_token: 'refresh',
+        token_type: 'bearer',
+      }),
+    });
+    mockSignIn.mockResolvedValue({ error: 'LoginFailed' });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('should show error message when email is already registered', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'emailAlreadyRegistered' }),
+    });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'existing@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This email is already registered')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show generic error message when registration fails', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'registrationFailed' }),
+    });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registration failed. Please try again')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show error message on network error', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Network error')
+    );
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registration failed. Please try again')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show loading state while submitting', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: async () => ({
+                  access_token: 'token',
+                  refresh_token: 'refresh',
+                  token_type: 'bearer',
+                }),
+              }),
+            100
+          )
+        )
+    );
+    mockSignIn.mockResolvedValue({ error: null });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should disable inputs while loading', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: async () => ({
+                  access_token: 'token',
+                  refresh_token: 'refresh',
+                  token_type: 'bearer',
+                }),
+              }),
+            100
+          )
+        )
+    );
+    mockSignIn.mockResolvedValue({ error: null });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    const nameInput = getNameInput();
+    const passwordInput = document.querySelector(
+      'input[name="password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInput = document.querySelector(
+      'input[name="confirmPassword"]'
+    ) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /sign up/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.type(nameInput, 'Test User');
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'password123');
+    await user.click(submitButton);
+
+    expect(emailInput).toBeDisabled();
+    expect(nameInput).toBeDisabled();
+    expect(passwordInput).toBeDisabled();
+    expect(confirmPasswordInput).toBeDisabled();
+
+    await waitFor(() => {
+      expect(emailInput).not.toBeDisabled();
+    });
+  });
+
+  it('should have email input with type email for browser validation', () => {
+    render(<RegisterForm />);
+
+    const emailInput = getEmailInput();
+    expect(emailInput).toHaveAttribute('type', 'email');
+  });
+});

--- a/frontend/app/[locale]/(auth)/register/page.tsx
+++ b/frontend/app/[locale]/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
-import { useTranslations } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
+
+import { RegisterForm } from '@/components/auth/RegisterForm';
 
 interface RegisterPageProps {
   params: Promise<{ locale: string }>;
@@ -9,21 +10,9 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  return <RegisterContent />;
-}
-
-function RegisterContent() {
-  const t = useTranslations('auth');
-
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md space-y-8 p-8">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold">{t('signUpTitle')}</h1>
-          <p className="mt-2 text-gray-600">{t('signUpDescription')}</p>
-        </div>
-        {/* TODO: 登録フォームを実装 */}
-      </div>
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <RegisterForm />
     </div>
   );
 }

--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+
+interface RegisterRequest {
+  email: string;
+  name: string;
+  password: string;
+}
+
+interface RegisterResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}
+
+interface ErrorResponse {
+  detail: string;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body: RegisterRequest = await request.json();
+
+    const response = await fetch(
+      `${process.env.BACKEND_URL}/api/v1/auth/register`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: body.email,
+          name: body.name,
+          password: body.password,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorData: ErrorResponse = await response.json();
+
+      if (response.status === 400) {
+        return NextResponse.json(
+          { error: 'emailAlreadyRegistered' },
+          { status: 400 }
+        );
+      }
+
+      if (response.status === 422) {
+        return NextResponse.json({ error: 'validationError' }, { status: 422 });
+      }
+
+      return NextResponse.json(
+        { error: errorData.detail || 'registrationFailed' },
+        { status: response.status }
+      );
+    }
+
+    const data: RegisterResponse = await response.json();
+
+    return NextResponse.json(data, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'registrationFailed' }, { status: 500 });
+  }
+}

--- a/frontend/components/auth/RegisterForm.tsx
+++ b/frontend/components/auth/RegisterForm.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { signIn } from 'next-auth/react';
+import { useTranslations } from 'next-intl';
+import { Eye, EyeOff, Loader2 } from 'lucide-react';
+
+import { Link, useRouter } from '@/i18n/routing';
+import {
+  createRegisterSchema,
+  type RegisterFormData,
+} from '@/lib/validations/auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+
+export function RegisterForm() {
+  const t = useTranslations('auth');
+  const tCommon = useTranslations('common');
+  const router = useRouter();
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const registerSchema = createRegisterSchema({
+    emailRequired: t('emailRequired'),
+    emailInvalid: t('emailInvalid'),
+    nameRequired: t('nameRequired'),
+    nameTooLong: t('nameTooLong'),
+    passwordMinLength: t('passwordMinLength'),
+    passwordNeedsLetter: t('passwordNeedsLetter'),
+    passwordNeedsNumber: t('passwordNeedsNumber'),
+    confirmPasswordRequired: t('confirmPasswordRequired'),
+    passwordsMustMatch: t('passwordsMustMatch'),
+  });
+
+  const form = useForm<RegisterFormData>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      email: '',
+      name: '',
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  async function onSubmit(data: RegisterFormData) {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: data.email,
+          name: data.name,
+          password: data.password,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        if (errorData.error === 'emailAlreadyRegistered') {
+          setError(t('emailAlreadyRegistered'));
+        } else {
+          setError(t('registrationFailed'));
+        }
+        return;
+      }
+
+      // Registration successful, auto-login
+      const result = await signIn('credentials', {
+        redirect: false,
+        email: data.email,
+        password: data.password,
+      });
+
+      if (result?.error) {
+        // Login failed after registration, redirect to login page
+        router.push('/login');
+      } else {
+        router.push('/');
+      }
+    } catch {
+      setError(t('registrationFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">{t('signUpTitle')}</CardTitle>
+        <CardDescription>{t('signUpDescription')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('email')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="email@example.com"
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('name')}</FormLabel>
+                  <FormControl>
+                    <Input disabled={isLoading} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('password')}</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type={showPassword ? 'text' : 'password'}
+                        disabled={isLoading}
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="absolute top-1/2 right-1 -translate-y-1/2"
+                        onClick={() => setShowPassword(!showPassword)}
+                        disabled={isLoading}
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                        <span className="sr-only">
+                          {showPassword ? 'Hide password' : 'Show password'}
+                        </span>
+                      </Button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('confirmPassword')}</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type={showConfirmPassword ? 'text' : 'password'}
+                        disabled={isLoading}
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="absolute top-1/2 right-1 -translate-y-1/2"
+                        onClick={() =>
+                          setShowConfirmPassword(!showConfirmPassword)
+                        }
+                        disabled={isLoading}
+                      >
+                        {showConfirmPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                        <span className="sr-only">
+                          {showConfirmPassword
+                            ? 'Hide password'
+                            : 'Show password'}
+                        </span>
+                      </Button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {error && (
+              <p className="text-destructive text-center text-sm">{error}</p>
+            )}
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {tCommon('loading')}
+                </>
+              ) : (
+                t('register')
+              )}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+      <CardFooter className="justify-center">
+        <p className="text-muted-foreground text-sm">
+          {t('hasAccount')}{' '}
+          <Link href="/login" className="text-primary hover:underline">
+            {t('login')}
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/lib/validations/auth.ts
+++ b/frontend/lib/validations/auth.ts
@@ -15,3 +15,41 @@ export function createLoginSchema(messages: {
 }
 
 export type LoginFormData = z.infer<ReturnType<typeof createLoginSchema>>;
+
+export function createRegisterSchema(messages: {
+  emailRequired: string;
+  emailInvalid: string;
+  nameRequired: string;
+  nameTooLong: string;
+  passwordMinLength: string;
+  passwordNeedsLetter: string;
+  passwordNeedsNumber: string;
+  confirmPasswordRequired: string;
+  passwordsMustMatch: string;
+}) {
+  return z
+    .object({
+      email: z
+        .string()
+        .min(1, { message: messages.emailRequired })
+        .email({ message: messages.emailInvalid }),
+      name: z
+        .string()
+        .min(1, { message: messages.nameRequired })
+        .max(100, { message: messages.nameTooLong }),
+      password: z
+        .string()
+        .min(8, { message: messages.passwordMinLength })
+        .regex(/[a-zA-Z]/, { message: messages.passwordNeedsLetter })
+        .regex(/[0-9]/, { message: messages.passwordNeedsNumber }),
+      confirmPassword: z
+        .string()
+        .min(1, { message: messages.confirmPasswordRequired }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: messages.passwordsMustMatch,
+      path: ['confirmPassword'],
+    });
+}
+
+export type RegisterFormData = z.infer<ReturnType<typeof createRegisterSchema>>;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -44,7 +44,16 @@
     "accountDisabled": "This account has been disabled",
     "emailRequired": "Email is required",
     "emailInvalid": "Please enter a valid email address",
-    "passwordRequired": "Password is required"
+    "passwordRequired": "Password is required",
+    "nameRequired": "Name is required",
+    "nameTooLong": "Name must be 100 characters or less",
+    "passwordMinLength": "Password must be at least 8 characters",
+    "passwordNeedsLetter": "Password must contain at least one letter",
+    "passwordNeedsNumber": "Password must contain at least one number",
+    "confirmPasswordRequired": "Please confirm your password",
+    "passwordsMustMatch": "Passwords do not match",
+    "emailAlreadyRegistered": "This email is already registered",
+    "registrationFailed": "Registration failed. Please try again"
   },
   "projects": {
     "title": "Projects",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -44,7 +44,16 @@
     "accountDisabled": "このアカウントは無効化されています",
     "emailRequired": "メールアドレスを入力してください",
     "emailInvalid": "有効なメールアドレスを入力してください",
-    "passwordRequired": "パスワードを入力してください"
+    "passwordRequired": "パスワードを入力してください",
+    "nameRequired": "名前を入力してください",
+    "nameTooLong": "名前は100文字以内で入力してください",
+    "passwordMinLength": "パスワードは8文字以上で入力してください",
+    "passwordNeedsLetter": "パスワードには英字を含めてください",
+    "passwordNeedsNumber": "パスワードには数字を含めてください",
+    "confirmPasswordRequired": "確認用パスワードを入力してください",
+    "passwordsMustMatch": "パスワードが一致しません",
+    "emailAlreadyRegistered": "このメールアドレスは既に登録されています",
+    "registrationFailed": "登録に失敗しました。もう一度お試しください"
   },
   "projects": {
     "title": "プロジェクト",


### PR DESCRIPTION
## Summary
   - RegisterFormコンポーネントをReact Hook Form + Zodバリデーションで実装
   - `/api/auth/register` API routeを作成（バックエンドプロキシ）
   - 登録用バリデーションスキーマ（email, name, password, confirmPassword）を追加
   - 翻訳キーを日英両方に追加
   - パスワード表示/非表示トグル（2箇所）
   - 登録成功後の自動ログイン機能
   - 包括的なテスト（19ケース）

   ## Test plan
   - [x] `npm run test:run` - 全52テストパス
   - [x] `npm run lint && npm run format:check` - エラーなし
   - [x] Docker Compose動作確認 - 全サービスhealthy
   - [x] 登録API動作確認 - トークン返却成功
   - [x] 重複メールエラー確認 - 正しくエラー返却
   - [x] `/ja/register`, `/en/register` - HTTP 200