### PR TITLE
ci: add generate-client and pre-commit workflows (#36)

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -1,0 +1,76 @@
+name: Generate API Client
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/app/**"
+
+jobs:
+  generate-client:
+    name: Generate Client
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "api/uv.lock"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+        working-directory: api
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Node.js dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Generate OpenAPI schema
+        run: |
+          cd api
+          uv run python -c "import app.main; import json; print(json.dumps(app.main.app.openapi()))" > ../web/openapi.json
+
+      - name: Generate API client
+        run: npm run openapi-ts
+        working-directory: web
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git diff --quiet web/client/ web/openapi.json || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: regenerate API client from OpenAPI schema"
+          title: "chore: regenerate API client from OpenAPI schema"
+          body: |
+            This PR was automatically generated because the API schema has changed.
+
+            ## Changes
+            - Updated OpenAPI schema (`web/openapi.json`)
+            - Regenerated TypeScript client (`web/client/`)
+
+            Please review the changes and merge if they look correct.
+          branch: chore/regenerate-api-client
+          delete-branch: true
+          labels: |
+            automated
+            api-client

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,55 @@
+name: Pre-commit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    name: Code Quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "api/uv.lock"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --extra dev
+        working-directory: api
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Node.js dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Python lint (ruff check)
+        run: uv run ruff check .
+        working-directory: api
+
+      - name: Python format check (ruff format)
+        run: uv run ruff format --check .
+        working-directory: api
+
+      - name: TypeScript lint (eslint)
+        run: npm run lint
+        working-directory: web
+
+      - name: TypeScript format check (prettier)
+        run: npm run format:check
+        working-directory: web

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^api/
+      - id: ruff-format
+        files: ^api/
+
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx prettier --write --ignore-unknown
+        language: system
+        files: ^web/.*\.(js|jsx|ts|tsx|json|css|md)$
+        exclude: ^web/(client|\.next)/
+
+      - id: eslint
+        name: eslint
+        entry: bash -c 'cd web && npx eslint --fix'
+        language: system
+        files: ^web/.*\.(js|jsx|ts|tsx)$
+        exclude: ^web/(client|\.next)/
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -115,6 +115,38 @@ npx playwright test
 
 詳細なテスト戦略については [docs/REQUIREMENTS.md](docs/REQUIREMENTS.md#テスト戦略) を参照してください。
 
+### API クライアント生成
+
+バックエンドの OpenAPI スキーマから TypeScript クライアントを自動生成しています。
+
+```bash
+# API クライアントの再生成
+./scripts/generate-client.sh
+```
+
+生成されたクライアントは `web/client/` に配置され、型安全な API 呼び出しが可能です。
+
+> **Note:** `api/app/` 配下のファイルが変更されると、CI が自動でクライアントを再生成する PR を作成します。
+
+### Pre-commit フック
+
+コード品質を保つため、pre-commit フックを設定できます。
+
+```bash
+# pre-commit のインストール
+pip install pre-commit
+
+# フックのインストール
+pre-commit install
+
+# 全ファイルに対して手動実行（オプション）
+pre-commit run --all-files
+```
+
+設定済みのチェック:
+- **Python**: ruff (リント・フォーマット)
+- **TypeScript**: prettier, eslint
+
 ## ドキュメント
 
 - [要件定義書](docs/REQUIREMENTS.md) - 機能要件、非機能要件、テスト戦略、API 設計など

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,6 +11,7 @@
 3. [開発フロー](#開発フロー)
 4. [確認フロー](#確認フロー)
 5. [コマンドリファレンス](#コマンドリファレンス)
+6. [API クライアント再生成](#api-クライアント再生成)
 
 ---
 
@@ -183,6 +184,9 @@ npm run lint
 npm run format:check
 ```
 
+> **Tip:** pre-commit フックを設定すると、コミット時に自動でこれらのチェックを実行できます。
+> 詳細は [README.md](../README.md#pre-commit-フック) を参照してください。
+
 ### Step 4: Docker Compose での動作確認
 
 #### 4.1 サービスのビルドと起動
@@ -203,8 +207,8 @@ docker compose ps
 
 ```
 NAME       STATUS
-backend    Up (healthy)
-frontend   Up
+api        Up (healthy)
+web        Up
 postgres   Up (healthy)
 redis      Up (healthy)
 ```
@@ -355,6 +359,38 @@ fi
 
 echo "=== 確認フロー完了 ✅ ==="
 ```
+
+---
+
+## API クライアント再生成
+
+バックエンドの API スキーマを変更した場合、フロントエンドのクライアントコードを再生成する必要があります。
+
+### 手動再生成
+
+```bash
+# プロジェクトルートから実行
+./scripts/generate-client.sh
+```
+
+このスクリプトは以下を実行します：
+
+1. バックエンドから OpenAPI スキーマを抽出
+2. `@hey-api/openapi-ts` でクライアントコードを生成
+3. `web/client/` に出力
+
+### CI による自動再生成
+
+`api/app/` 配下のファイルが `main` ブランチにマージされると、CI が自動でクライアントを再生成し、差分がある場合は PR を作成します。
+
+### 生成されるファイル
+
+| ファイル | 内容 |
+|---------|------|
+| `sdk.gen.ts` | API 呼び出し関数 |
+| `types.gen.ts` | TypeScript 型定義 |
+| `zod.gen.ts` | Zod バリデーションスキーマ |
+| `@tanstack/react-query.gen.ts` | React Query フック |
 
 ---
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -352,6 +352,56 @@ export function MyComponent() {
 
 ---
 
+## API Client (hey-api)
+
+### Overview
+
+Backend API client is auto-generated from OpenAPI schema using `@hey-api/openapi-ts`.
+
+```
+web/client/
+├── sdk.gen.ts              # API functions
+├── types.gen.ts            # TypeScript types
+├── zod.gen.ts              # Zod schemas
+├── @tanstack/
+│   └── react-query.gen.ts  # React Query hooks
+└── client/
+    └── client.gen.ts       # Axios client wrapper
+```
+
+### Usage
+
+```tsx
+// Server-side (API routes, Server Components)
+import { loginApiV1AuthLoginPost } from '@/client';
+import { getServerClient } from '@/lib/api/client';
+
+const { data, error } = await loginApiV1AuthLoginPost({
+  client: getServerClient(),
+  body: { email, password },
+});
+
+// Client-side (with React Query)
+import { useLoginApiV1AuthLoginPost } from '@/client/@tanstack/react-query.gen';
+
+const mutation = useLoginApiV1AuthLoginPost();
+mutation.mutate({ body: { email, password } });
+```
+
+### Regenerating Client
+
+```bash
+# From project root
+./scripts/generate-client.sh
+
+# Or from web directory
+npm run openapi-ts
+```
+
+> **Note:** CI automatically creates a PR when API schema changes in `api/app/`.
+
+---
+
 ## Path Aliases
 
 ```tsx


### PR DESCRIPTION
## Summary

- Add `generate-client.yml` workflow to auto-regenerate API client when backend API changes
- Add `pre-commit.yml` workflow to run code quality checks (ruff, eslint, prettier) on PRs
- Add `.pre-commit-config.yaml` for local development pre-commit hooks
- Add hey-api documentation to README.md, web/AGENTS.md, and docs/DEVELOPMENT.md
- Fix docker-compose service names in DEVELOPMENT.md (backend→api, frontend→web)

## New Workflows

### generate-client.yml
- Triggered on push to main when `api/app/**` files change
- Extracts OpenAPI schema from backend
- Generates TypeScript client using `@hey-api/openapi-ts`
- Creates PR if there are changes

### pre-commit.yml
- Triggered on PRs to main
- Runs Python checks: `ruff check`, `ruff format --check`
- Runs TypeScript checks: `eslint`, `prettier --check`

## Test plan

- [ ] Verify pre-commit workflow runs on this PR
- [ ] Review generate-client.yml configuration
- [ ] Check documentation updates are accurate

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)