### PR TITLE
fix: update prettier pre-commit hook to handle web/ prefix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: npx prettier --write --ignore-unknown
+        entry: bash -c 'cd web && npx prettier --write --ignore-unknown "${@#web/}"' --
         language: system
         files: ^web/.*\.(js|jsx|ts|tsx|json|css|md)$
         exclude: ^web/(client|\.next)/


### PR DESCRIPTION
## Summary

Fix prettier pre-commit hook that was failing due to file path resolution issues.

## Problem

When running `pre-commit run --all-files`, prettier failed because:
1. Files are passed with `web/` prefix (e.g., `web/app/page.tsx`)
2. Prettier needs to run from `web/` directory to find `prettier-plugin-tailwindcss`
3. After `cd web`, the file paths with `web/` prefix no longer exist

## Solution

Update the prettier hook entry to:
- Change directory to `web/`
- Strip the `web/` prefix from file paths using `${@#web/}`

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)