### PR TITLE
feat: Authentication Middleware (Route Protection)

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,18 +1,65 @@
 import createMiddleware from 'next-intl/middleware';
 import { NextRequest, NextResponse } from 'next/server';
 import { routing } from './i18n/routing';
+import { auth } from './auth';
+import {
+  isPublicRoute,
+  isProtectedRoute,
+  isAdminRoute,
+  isPublicDocsRoute,
+} from './shared/lib/routes';
+import { locales, defaultLocale } from './i18n/config';
 
 const intlMiddleware = createMiddleware(routing);
 
-export default function middleware(request: NextRequest) {
+/**
+ * Extract the pathname without locale prefix
+ */
+function getPathWithoutLocale(pathname: string): string {
+  for (const locale of locales) {
+    if (pathname.startsWith(`/${locale}/`)) {
+      return pathname.slice(locale.length + 1);
+    }
+    if (pathname === `/${locale}`) {
+      return '/';
+    }
+  }
+  return pathname;
+}
+
+/**
+ * Get the locale from the pathname
+ */
+function getLocaleFromPath(pathname: string): string {
+  for (const locale of locales) {
+    if (pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`) {
+      return locale;
+    }
+  }
+  return defaultLocale;
+}
+
+/**
+ * Create a redirect URL with locale
+ */
+function createLocalizedUrl(
+  request: NextRequest,
+  path: string,
+  locale: string
+): URL {
+  const url = new URL(`/${locale}${path}`, request.url);
+  return url;
+}
+
+export default auth(async function middleware(request) {
   const { pathname } = request.nextUrl;
 
-  // Skip locale handling for API routes
+  // Skip middleware for API routes
   if (pathname.startsWith('/api/')) {
     return NextResponse.next();
   }
 
-  // Skip locale handling for static files
+  // Skip middleware for static files
   if (
     pathname.startsWith('/_next/') ||
     pathname.includes('/favicon.ico') ||
@@ -21,8 +68,50 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Get path without locale and current locale
+  const pathWithoutLocale = getPathWithoutLocale(pathname);
+  const locale = getLocaleFromPath(pathname);
+
+  // Get session from auth
+  const session = request.auth;
+  const isAuthenticated = !!session?.user;
+  const isAdmin = session?.user?.isAdmin ?? false;
+
+  // Public docs are accessible to everyone
+  if (isPublicDocsRoute(pathWithoutLocale)) {
+    return intlMiddleware(request);
+  }
+
+  // Redirect authenticated users away from login/register pages
+  if (isAuthenticated && isPublicRoute(pathWithoutLocale)) {
+    const redirectUrl = createLocalizedUrl(request, '/', locale);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  // Redirect unauthenticated users to login for protected routes
+  if (!isAuthenticated && isProtectedRoute(pathWithoutLocale)) {
+    const redirectUrl = createLocalizedUrl(request, '/login', locale);
+    // Store the original URL to redirect back after login
+    redirectUrl.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  // Redirect non-admin users away from admin routes
+  if (isAdminRoute(pathWithoutLocale)) {
+    if (!isAuthenticated) {
+      const redirectUrl = createLocalizedUrl(request, '/login', locale);
+      redirectUrl.searchParams.set('callbackUrl', pathname);
+      return NextResponse.redirect(redirectUrl);
+    }
+    if (!isAdmin) {
+      const redirectUrl = createLocalizedUrl(request, '/', locale);
+      return NextResponse.redirect(redirectUrl);
+    }
+  }
+
+  // Continue with i18n middleware for all other cases
   return intlMiddleware(request);
-}
+});
 
 export const config = {
   // Match all pathnames except for

--- a/web/shared/lib/__tests__/routes.test.ts
+++ b/web/shared/lib/__tests__/routes.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  matchesRoute,
+  isPublicRoute,
+  isProtectedRoute,
+  isAdminRoute,
+  isPublicDocsRoute,
+  PUBLIC_ROUTES,
+  PROTECTED_ROUTES,
+  ADMIN_ROUTES,
+} from '../routes';
+
+describe('routes configuration', () => {
+  describe('PUBLIC_ROUTES', () => {
+    it('should include login and register', () => {
+      expect(PUBLIC_ROUTES).toContain('/login');
+      expect(PUBLIC_ROUTES).toContain('/register');
+    });
+  });
+
+  describe('PROTECTED_ROUTES', () => {
+    it('should include root, projects, and chat', () => {
+      expect(PROTECTED_ROUTES).toContain('/');
+      expect(PROTECTED_ROUTES).toContain('/projects');
+      expect(PROTECTED_ROUTES).toContain('/chat');
+    });
+  });
+
+  describe('ADMIN_ROUTES', () => {
+    it('should include admin', () => {
+      expect(ADMIN_ROUTES).toContain('/admin');
+    });
+  });
+});
+
+describe('matchesRoute', () => {
+  it('should match exact routes', () => {
+    expect(matchesRoute('/login', ['/login'])).toBe(true);
+    expect(matchesRoute('/register', ['/register'])).toBe(true);
+  });
+
+  it('should match prefix routes', () => {
+    expect(matchesRoute('/projects/123', ['/projects'])).toBe(true);
+    expect(matchesRoute('/projects/abc/edit', ['/projects'])).toBe(true);
+    expect(matchesRoute('/chat/project-1', ['/chat'])).toBe(true);
+  });
+
+  it('should handle root path correctly', () => {
+    expect(matchesRoute('/', ['/'])).toBe(true);
+    expect(matchesRoute('/login', ['/'])).toBe(false);
+    expect(matchesRoute('/projects', ['/'])).toBe(false);
+  });
+
+  it('should return false for non-matching routes', () => {
+    expect(matchesRoute('/other', ['/login', '/register'])).toBe(false);
+    expect(matchesRoute('/loginx', ['/login'])).toBe(false);
+  });
+});
+
+describe('isPublicRoute', () => {
+  it('should return true for login route', () => {
+    expect(isPublicRoute('/login')).toBe(true);
+  });
+
+  it('should return true for register route', () => {
+    expect(isPublicRoute('/register')).toBe(true);
+  });
+
+  it('should return false for protected routes', () => {
+    expect(isPublicRoute('/')).toBe(false);
+    expect(isPublicRoute('/projects')).toBe(false);
+    expect(isPublicRoute('/chat')).toBe(false);
+  });
+
+  it('should return false for admin routes', () => {
+    expect(isPublicRoute('/admin')).toBe(false);
+    expect(isPublicRoute('/admin/users')).toBe(false);
+  });
+});
+
+describe('isProtectedRoute', () => {
+  it('should return true for root path', () => {
+    expect(isProtectedRoute('/')).toBe(true);
+  });
+
+  it('should return true for projects routes', () => {
+    expect(isProtectedRoute('/projects')).toBe(true);
+    expect(isProtectedRoute('/projects/123')).toBe(true);
+    expect(isProtectedRoute('/projects/abc/edit')).toBe(true);
+  });
+
+  it('should return true for chat routes', () => {
+    expect(isProtectedRoute('/chat')).toBe(true);
+    expect(isProtectedRoute('/chat/project-1')).toBe(true);
+    expect(isProtectedRoute('/chat/project-1/conv-1')).toBe(true);
+  });
+
+  it('should return false for public routes', () => {
+    expect(isProtectedRoute('/login')).toBe(false);
+    expect(isProtectedRoute('/register')).toBe(false);
+  });
+
+  it('should return false for docs routes', () => {
+    expect(isProtectedRoute('/docs')).toBe(false);
+    expect(isProtectedRoute('/docs/project-1')).toBe(false);
+  });
+});
+
+describe('isAdminRoute', () => {
+  it('should return true for admin routes', () => {
+    expect(isAdminRoute('/admin')).toBe(true);
+    expect(isAdminRoute('/admin/users')).toBe(true);
+    expect(isAdminRoute('/admin/settings')).toBe(true);
+    expect(isAdminRoute('/admin/groups')).toBe(true);
+  });
+
+  it('should return false for non-admin routes', () => {
+    expect(isAdminRoute('/')).toBe(false);
+    expect(isAdminRoute('/login')).toBe(false);
+    expect(isAdminRoute('/projects')).toBe(false);
+  });
+});
+
+describe('isPublicDocsRoute', () => {
+  it('should return true for docs root', () => {
+    expect(isPublicDocsRoute('/docs')).toBe(true);
+  });
+
+  it('should return true for docs subpaths', () => {
+    expect(isPublicDocsRoute('/docs/project-1')).toBe(true);
+    expect(isPublicDocsRoute('/docs/project-1/page')).toBe(true);
+    expect(isPublicDocsRoute('/docs/project-1/section/page')).toBe(true);
+  });
+
+  it('should return false for non-docs routes', () => {
+    expect(isPublicDocsRoute('/')).toBe(false);
+    expect(isPublicDocsRoute('/documents')).toBe(false);
+    expect(isPublicDocsRoute('/docsx')).toBe(false);
+  });
+});

--- a/web/shared/lib/routes.ts
+++ b/web/shared/lib/routes.ts
@@ -1,0 +1,57 @@
+/**
+ * Route configuration for authentication middleware
+ */
+
+// Routes that don't require authentication
+export const PUBLIC_ROUTES = ['/login', '/register'];
+
+// Routes that require authentication
+export const PROTECTED_ROUTES = ['/', '/projects', '/chat'];
+
+// Routes that require admin role
+export const ADMIN_ROUTES = ['/admin'];
+
+// Public documentation routes (accessible to everyone)
+export const PUBLIC_DOCS_PATTERN = /^\/docs(\/.*)?$/;
+
+/**
+ * Check if a path matches any route in the list
+ * Handles both exact matches and prefix matches (e.g., /projects/123)
+ */
+export function matchesRoute(path: string, routes: string[]): boolean {
+  return routes.some((route) => {
+    if (route === '/') {
+      return path === '/';
+    }
+    return path === route || path.startsWith(`${route}/`);
+  });
+}
+
+/**
+ * Check if path is a public route (login, register)
+ */
+export function isPublicRoute(path: string): boolean {
+  return matchesRoute(path, PUBLIC_ROUTES);
+}
+
+/**
+ * Check if path is a protected route (requires authentication)
+ */
+export function isProtectedRoute(path: string): boolean {
+  // Root path or any protected route prefix
+  return matchesRoute(path, PROTECTED_ROUTES);
+}
+
+/**
+ * Check if path is an admin route
+ */
+export function isAdminRoute(path: string): boolean {
+  return matchesRoute(path, ADMIN_ROUTES);
+}
+
+/**
+ * Check if path is public documentation
+ */
+export function isPublicDocsRoute(path: string): boolean {
+  return PUBLIC_DOCS_PATTERN.test(path);
+}


### PR DESCRIPTION
## Summary

- Implement authentication middleware to protect routes based on user authentication status
- Add route configuration utilities for classifying public, protected, and admin routes
- Integrate NextAuth v5 with next-intl middleware for locale-aware redirects

## Changes

| File | Description |
|------|-------------|
| `web/middleware.ts` | Extended with auth check logic |
| `web/shared/lib/routes.ts` | Route classification constants and helper functions |
| `web/shared/lib/__tests__/routes.test.ts` | Unit tests (21 tests) |

## Route Protection

| Route | Behavior |
|-------|----------|
| `/login`, `/register` | Public (authenticated users redirect to `/`) |
| `/docs/*` | Public (accessible to everyone) |
| `/`, `/projects/*`, `/chat/*` | Protected (unauthenticated users redirect to `/login`) |
| `/admin/*` | Admin only (non-admins redirect to `/`) |

## Test plan

- [x] Unauthenticated user accessing `/` redirects to `/login`
- [x] Unauthenticated user can access `/login` and `/register`
- [x] Unauthenticated user can access `/docs/*`
- [x] Authenticated user accessing `/login` redirects to `/`
- [x] Non-admin user accessing `/admin/*` redirects to `/`
- [x] `callbackUrl` parameter preserved for post-login redirect
- [x] Unit tests pass (21 tests)

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)