### PR TITLE
chore: add Docker Compose integration test workflow

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -1,0 +1,46 @@
+name: Test Docker Compose
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-docker-compose:
+    name: Docker Compose Integration Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build images
+        run: docker compose build
+
+      - name: Start services
+        run: docker compose up -d --wait
+
+      - name: Run database migrations
+        run: docker compose exec -T api alembic upgrade head
+
+      - name: Test API health check
+        run: |
+          curl --fail --retry 5 --retry-delay 5 \
+            http://localhost:8000/api/v1/health
+
+      - name: Test frontend is accessible
+        run: |
+          curl --fail --retry 5 --retry-delay 5 \
+            -o /dev/null -w "%{http_code}" \
+            http://localhost:3000/ja/login | grep -q "200"
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v --remove-orphans


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to test that Docker Compose builds and runs correctly, ensuring the entire application stack works together.

## Changes

New workflow `.github/workflows/test-docker-compose.yml`:

| Step | Description |
|------|-------------|
| Build images | `docker compose build` |
| Start services | `docker compose up -d --wait` |
| Run migrations | `alembic upgrade head` |
| API health check | `curl /api/v1/health` |
| Frontend check | `curl /ja/login` (expect 200) |
| Show logs | On failure, for debugging |
| Cleanup | `docker compose down -v` |

### Triggers
- Push to `main`
- Pull requests to `main`

## Test plan

- [ ] Workflow triggers on PR
- [ ] Docker images build successfully
- [ ] All services start with health checks
- [ ] Migrations run successfully
- [ ] API and frontend are accessible

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)