### PR TITLE
fix(ci): add package_json_file to pnpm/action-setup in generate-client workflow

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
`Generate API Client` ワークフローで `pnpm/action-setup@v4` に `package_json_file: web/package.json` を追加。

## Cause
`packageManager` フィールドが `web/package.json` にのみ存在するため、ルートの `package.json` を参照するとpnpmバージョンが見つからずエラーになる。

## Test plan
- [x] CIが通過することを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)