### PR TITLE
refactor: add service layer to backend architecture

### DIFF
--- a/api/app/api/v1/endpoints/auth.py
+++ b/api/app/api/v1/endpoints/auth.py
@@ -1,7 +1,6 @@
 """Authentication endpoints."""
 
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -9,14 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_active_user
 from app.core.database import get_db
-from app.core.redis import add_token_to_blacklist, is_token_blacklisted
-from app.core.security import (
-    create_access_token,
-    create_refresh_token,
-    decode_token,
-    hash_password,
-    verify_password,
-)
 from app.models.user import User
 from app.repositories.user import UserRepository
 from app.schemas.auth import (
@@ -26,9 +17,28 @@ from app.schemas.auth import (
     TokenResponse,
 )
 from app.schemas.user import UserRead
+from app.services import (
+    AuthService,
+    EmailAlreadyExistsError,
+    InvalidCredentialsError,
+    InvalidTokenError,
+    UserInactiveError,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 security = HTTPBearer()
+
+
+def get_auth_service(db: AsyncSession = Depends(get_db)) -> AuthService:
+    """Dependency to get AuthService instance.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        AuthService instance with UserRepository.
+    """
+    return AuthService(UserRepository(db))
 
 
 @router.post(
@@ -36,13 +46,13 @@ security = HTTPBearer()
 )
 async def register(
     request: RegisterRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> TokenResponse:
     """Register a new user.
 
     Args:
         request: Registration request containing email, name, and password.
-        db: Database session.
+        auth_service: Authentication service.
 
     Returns:
         Access and refresh tokens.
@@ -50,120 +60,74 @@ async def register(
     Raises:
         HTTPException: If email is already registered.
     """
-    user_repo = UserRepository(db)
-
-    # Check if email already exists
-    if await user_repo.email_exists(request.email):
+    try:
+        return await auth_service.register(
+            email=request.email,
+            name=request.name,
+            password=request.password,
+        )
+    except EmailAlreadyExistsError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Email already registered",
-        )
-
-    # Create user with hashed password
-    hashed_password = hash_password(request.password)
-    user = await user_repo.create(
-        email=request.email,
-        name=request.name,
-        password_hash=hashed_password,
-        auth_provider="local",
-    )
-
-    # Generate tokens
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
-
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-    )
+            detail=str(e),
+        ) from e
 
 
 @router.post("/login", response_model=TokenResponse)
 async def login(
     request: LoginRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> TokenResponse:
     """Login with email and password.
 
     Args:
         request: Login request containing email and password.
-        db: Database session.
+        auth_service: Authentication service.
 
     Returns:
         Access and refresh tokens.
 
     Raises:
-        HTTPException: If credentials are invalid.
+        HTTPException: If credentials are invalid or user is inactive.
     """
-    user_repo = UserRepository(db)
-
-    # Get user by email
-    user = await user_repo.get_by_email(request.email)
-    if user is None:
+    try:
+        return await auth_service.login(request.email, request.password)
+    except InvalidCredentialsError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid email or password",
-        )
-
-    # Verify password
-    if user.password_hash is None or not verify_password(
-        request.password, user.password_hash
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid email or password",
-        )
-
-    # Check if user is active
-    if not user.is_active:
+            detail=str(e),
+        ) from e
+    except UserInactiveError as e:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="User account is inactive",
-        )
-
-    # Generate tokens
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
-
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-    )
+            detail=str(e),
+        ) from e
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 async def logout(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> None:
     """Logout and invalidate the current access token.
 
     Args:
         credentials: HTTP Bearer credentials containing the JWT token.
+        auth_service: Authentication service.
     """
-    token = credentials.credentials
-
-    # Decode token to get expiration time
-    payload = decode_token(token)
-    if payload is not None:
-        # Calculate remaining time until expiration
-        from datetime import UTC, datetime
-
-        now = datetime.now(UTC)
-        if payload.exp > now:
-            expires_in = payload.exp - now
-            await add_token_to_blacklist(token, expires_in)
+    await auth_service.logout(credentials.credentials)
 
 
 @router.post("/refresh", response_model=TokenResponse)
 async def refresh(
     request: RefreshTokenRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> TokenResponse:
     """Refresh access token using a refresh token.
 
     Args:
         request: Refresh token request.
-        db: Database session.
+        auth_service: Authentication service.
 
     Returns:
         New access and refresh tokens.
@@ -171,52 +135,13 @@ async def refresh(
     Raises:
         HTTPException: If refresh token is invalid.
     """
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Invalid refresh token",
-    )
-
-    # Check if token is blacklisted
-    if await is_token_blacklisted(request.refresh_token):
-        raise credentials_exception
-
-    # Decode refresh token
-    payload = decode_token(request.refresh_token)
-    if payload is None:
-        raise credentials_exception
-
-    # Ensure it's a refresh token
-    if payload.type != "refresh":
-        raise credentials_exception
-
-    # Get user from database
     try:
-        user_id = UUID(payload.sub)
-    except ValueError:
-        raise credentials_exception from None
-
-    user_repo = UserRepository(db)
-    user = await user_repo.get_by_id(user_id)
-
-    if user is None or not user.is_active:
-        raise credentials_exception
-
-    # Blacklist old refresh token
-    from datetime import UTC, datetime
-
-    now = datetime.now(UTC)
-    if payload.exp > now:
-        expires_in = payload.exp - now
-        await add_token_to_blacklist(request.refresh_token, expires_in)
-
-    # Generate new tokens
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
-
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-    )
+        return await auth_service.refresh_tokens(request.refresh_token)
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        ) from None
 
 
 @router.get("/me", response_model=UserRead)

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,1 +1,21 @@
 """Service layer for business logic."""
+
+from app.services.auth import AuthService
+from app.services.exceptions import (
+    AuthServiceError,
+    EmailAlreadyExistsError,
+    InvalidCredentialsError,
+    InvalidTokenError,
+    ServiceError,
+    UserInactiveError,
+)
+
+__all__ = [
+    "AuthService",
+    "AuthServiceError",
+    "EmailAlreadyExistsError",
+    "InvalidCredentialsError",
+    "InvalidTokenError",
+    "ServiceError",
+    "UserInactiveError",
+]

--- a/api/app/services/auth.py
+++ b/api/app/services/auth.py
@@ -1,0 +1,152 @@
+"""Authentication service for business logic."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from app.core.redis import add_token_to_blacklist, is_token_blacklisted
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+from app.repositories.user import UserRepository
+from app.schemas.auth import TokenResponse
+from app.services.exceptions import (
+    EmailAlreadyExistsError,
+    InvalidCredentialsError,
+    InvalidTokenError,
+    UserInactiveError,
+)
+
+
+class AuthService:
+    """Service for authentication operations."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        """Initialize the service with a user repository.
+
+        Args:
+            user_repo: Repository for user database operations.
+        """
+        self.user_repo = user_repo
+
+    async def register(self, email: str, name: str, password: str) -> TokenResponse:
+        """Register a new user and return tokens.
+
+        Args:
+            email: User's email address.
+            name: User's display name.
+            password: User's plain text password.
+
+        Returns:
+            Access and refresh tokens.
+
+        Raises:
+            EmailAlreadyExistsError: If email is already registered.
+        """
+        if await self.user_repo.email_exists(email):
+            raise EmailAlreadyExistsError("Email already registered")
+
+        hashed_password = hash_password(password)
+        user = await self.user_repo.create(
+            email=email,
+            name=name,
+            password_hash=hashed_password,
+            auth_provider="local",
+        )
+
+        return self._generate_tokens(user.id)
+
+    async def login(self, email: str, password: str) -> TokenResponse:
+        """Authenticate user and return tokens.
+
+        Args:
+            email: User's email address.
+            password: User's plain text password.
+
+        Returns:
+            Access and refresh tokens.
+
+        Raises:
+            InvalidCredentialsError: If email or password is invalid.
+            UserInactiveError: If user account is inactive.
+        """
+        user = await self.user_repo.get_by_email(email)
+
+        if user is None:
+            raise InvalidCredentialsError("Invalid email or password")
+
+        if user.password_hash is None or not verify_password(
+            password, user.password_hash
+        ):
+            raise InvalidCredentialsError("Invalid email or password")
+
+        if not user.is_active:
+            raise UserInactiveError("User account is inactive")
+
+        return self._generate_tokens(user.id)
+
+    async def logout(self, token: str) -> None:
+        """Invalidate the given token by adding it to the blacklist.
+
+        Args:
+            token: The JWT token to invalidate.
+        """
+        payload = decode_token(token)
+        if payload is not None:
+            now = datetime.now(UTC)
+            if payload.exp > now:
+                expires_in = payload.exp - now
+                await add_token_to_blacklist(token, expires_in)
+
+    async def refresh_tokens(self, refresh_token: str) -> TokenResponse:
+        """Refresh access token using refresh token.
+
+        Args:
+            refresh_token: The refresh token.
+
+        Returns:
+            New access and refresh tokens.
+
+        Raises:
+            InvalidTokenError: If refresh token is invalid or blacklisted.
+        """
+        if await is_token_blacklisted(refresh_token):
+            raise InvalidTokenError("Token is blacklisted")
+
+        payload = decode_token(refresh_token)
+        if payload is None or payload.type != "refresh":
+            raise InvalidTokenError("Invalid refresh token")
+
+        try:
+            user_id = UUID(payload.sub)
+        except ValueError:
+            raise InvalidTokenError("Invalid token payload") from None
+
+        user = await self.user_repo.get_by_id(user_id)
+        if user is None or not user.is_active:
+            raise InvalidTokenError("User not found or inactive")
+
+        # Blacklist old refresh token
+        now = datetime.now(UTC)
+        if payload.exp > now:
+            expires_in = payload.exp - now
+            await add_token_to_blacklist(refresh_token, expires_in)
+
+        return self._generate_tokens(user.id)
+
+    def _generate_tokens(self, user_id: UUID) -> TokenResponse:
+        """Generate access and refresh tokens for a user.
+
+        Args:
+            user_id: The user's UUID.
+
+        Returns:
+            TokenResponse containing access and refresh tokens.
+        """
+        return TokenResponse(
+            access_token=create_access_token(user_id),
+            refresh_token=create_refresh_token(user_id),
+        )

--- a/api/app/services/exceptions.py
+++ b/api/app/services/exceptions.py
@@ -1,0 +1,37 @@
+"""Service layer exceptions."""
+
+
+class ServiceError(Exception):
+    """Base exception for service layer errors."""
+
+    pass
+
+
+class AuthServiceError(ServiceError):
+    """Base exception for authentication service errors."""
+
+    pass
+
+
+class EmailAlreadyExistsError(AuthServiceError):
+    """Raised when email is already registered."""
+
+    pass
+
+
+class InvalidCredentialsError(AuthServiceError):
+    """Raised when credentials are invalid."""
+
+    pass
+
+
+class UserInactiveError(AuthServiceError):
+    """Raised when user account is inactive."""
+
+    pass
+
+
+class InvalidTokenError(AuthServiceError):
+    """Raised when token is invalid or blacklisted."""
+
+    pass

--- a/api/tests/services/__init__.py
+++ b/api/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer tests."""

--- a/api/tests/services/test_auth.py
+++ b/api/tests/services/test_auth.py
@@ -1,0 +1,418 @@
+"""Tests for authentication service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.repositories.user import UserRepository
+from app.services import (
+    AuthService,
+    EmailAlreadyExistsError,
+    InvalidCredentialsError,
+    InvalidTokenError,
+    UserInactiveError,
+)
+
+
+class TestAuthServiceRegister:
+    """Tests for AuthService.register method."""
+
+    @pytest.fixture
+    def mock_user_repo(self) -> MagicMock:
+        """Create a mock user repository."""
+        return MagicMock(spec=UserRepository)
+
+    @pytest.fixture
+    def auth_service(self, mock_user_repo: MagicMock) -> AuthService:
+        """Create an AuthService instance with mock repository."""
+        return AuthService(mock_user_repo)
+
+    @pytest.mark.asyncio
+    async def test_register_success(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test successful user registration."""
+        user_id = uuid4()
+        mock_user = MagicMock()
+        mock_user.id = user_id
+
+        mock_user_repo.email_exists = AsyncMock(return_value=False)
+        mock_user_repo.create = AsyncMock(return_value=mock_user)
+
+        with patch("app.services.auth.hash_password", return_value="hashed_password"):
+            result = await auth_service.register(
+                email="test@example.com",
+                name="Test User",
+                password="TestPassword123",
+            )
+
+        assert result.access_token is not None
+        assert result.refresh_token is not None
+        mock_user_repo.email_exists.assert_called_once_with("test@example.com")
+        mock_user_repo.create.assert_called_once_with(
+            email="test@example.com",
+            name="Test User",
+            password_hash="hashed_password",
+            auth_provider="local",
+        )
+
+    @pytest.mark.asyncio
+    async def test_register_email_already_exists(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test registration fails when email already exists."""
+        mock_user_repo.email_exists = AsyncMock(return_value=True)
+
+        with pytest.raises(EmailAlreadyExistsError, match="Email already registered"):
+            await auth_service.register(
+                email="existing@example.com",
+                name="Test User",
+                password="TestPassword123",
+            )
+
+        mock_user_repo.create.assert_not_called()
+
+
+class TestAuthServiceLogin:
+    """Tests for AuthService.login method."""
+
+    @pytest.fixture
+    def mock_user_repo(self) -> MagicMock:
+        """Create a mock user repository."""
+        return MagicMock(spec=UserRepository)
+
+    @pytest.fixture
+    def auth_service(self, mock_user_repo: MagicMock) -> AuthService:
+        """Create an AuthService instance with mock repository."""
+        return AuthService(mock_user_repo)
+
+    @pytest.mark.asyncio
+    async def test_login_success(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test successful login."""
+        user_id = uuid4()
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user.password_hash = "hashed_password"
+        mock_user.is_active = True
+
+        mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+
+        with patch("app.services.auth.verify_password", return_value=True):
+            result = await auth_service.login(
+                email="test@example.com",
+                password="TestPassword123",
+            )
+
+        assert result.access_token is not None
+        assert result.refresh_token is not None
+        mock_user_repo.get_by_email.assert_called_once_with("test@example.com")
+
+    @pytest.mark.asyncio
+    async def test_login_user_not_found(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test login fails when user is not found."""
+        mock_user_repo.get_by_email = AsyncMock(return_value=None)
+
+        with pytest.raises(InvalidCredentialsError, match="Invalid email or password"):
+            await auth_service.login(
+                email="nonexistent@example.com",
+                password="TestPassword123",
+            )
+
+    @pytest.mark.asyncio
+    async def test_login_wrong_password(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test login fails with wrong password."""
+        mock_user = MagicMock()
+        mock_user.password_hash = "hashed_password"
+        mock_user.is_active = True
+
+        mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+
+        with (
+            patch("app.services.auth.verify_password", return_value=False),
+            pytest.raises(InvalidCredentialsError, match="Invalid email or password"),
+        ):
+            await auth_service.login(
+                email="test@example.com",
+                password="WrongPassword123",
+            )
+
+    @pytest.mark.asyncio
+    async def test_login_no_password_hash(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test login fails when user has no password hash (OAuth user)."""
+        mock_user = MagicMock()
+        mock_user.password_hash = None
+        mock_user.is_active = True
+
+        mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+
+        with pytest.raises(InvalidCredentialsError, match="Invalid email or password"):
+            await auth_service.login(
+                email="oauth@example.com",
+                password="TestPassword123",
+            )
+
+    @pytest.mark.asyncio
+    async def test_login_inactive_user(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test login fails when user is inactive."""
+        mock_user = MagicMock()
+        mock_user.password_hash = "hashed_password"
+        mock_user.is_active = False
+
+        mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+
+        with (
+            patch("app.services.auth.verify_password", return_value=True),
+            pytest.raises(UserInactiveError, match="User account is inactive"),
+        ):
+            await auth_service.login(
+                email="inactive@example.com",
+                password="TestPassword123",
+            )
+
+
+class TestAuthServiceLogout:
+    """Tests for AuthService.logout method."""
+
+    @pytest.fixture
+    def mock_user_repo(self) -> MagicMock:
+        """Create a mock user repository."""
+        return MagicMock(spec=UserRepository)
+
+    @pytest.fixture
+    def auth_service(self, mock_user_repo: MagicMock) -> AuthService:
+        """Create an AuthService instance with mock repository."""
+        return AuthService(mock_user_repo)
+
+    @pytest.mark.asyncio
+    async def test_logout_success(self, auth_service: AuthService) -> None:
+        """Test successful logout adds token to blacklist."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_payload = MagicMock()
+        mock_payload.exp = datetime.now(UTC) + timedelta(hours=1)
+
+        with (
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            patch(
+                "app.services.auth.add_token_to_blacklist", new_callable=AsyncMock
+            ) as mock_blacklist,
+        ):
+            await auth_service.logout("valid_token")
+
+        mock_blacklist.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_logout_invalid_token(self, auth_service: AuthService) -> None:
+        """Test logout with invalid token does nothing."""
+        with (
+            patch("app.services.auth.decode_token", return_value=None),
+            patch(
+                "app.services.auth.add_token_to_blacklist", new_callable=AsyncMock
+            ) as mock_blacklist,
+        ):
+            await auth_service.logout("invalid_token")
+
+        mock_blacklist.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_logout_expired_token(self, auth_service: AuthService) -> None:
+        """Test logout with expired token does not add to blacklist."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_payload = MagicMock()
+        mock_payload.exp = datetime.now(UTC) - timedelta(hours=1)
+
+        with (
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            patch(
+                "app.services.auth.add_token_to_blacklist", new_callable=AsyncMock
+            ) as mock_blacklist,
+        ):
+            await auth_service.logout("expired_token")
+
+        mock_blacklist.assert_not_called()
+
+
+class TestAuthServiceRefreshTokens:
+    """Tests for AuthService.refresh_tokens method."""
+
+    @pytest.fixture
+    def mock_user_repo(self) -> MagicMock:
+        """Create a mock user repository."""
+        return MagicMock(spec=UserRepository)
+
+    @pytest.fixture
+    def auth_service(self, mock_user_repo: MagicMock) -> AuthService:
+        """Create an AuthService instance with mock repository."""
+        return AuthService(mock_user_repo)
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_success(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test successful token refresh."""
+        from datetime import UTC, datetime, timedelta
+
+        user_id = uuid4()
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user.is_active = True
+
+        mock_payload = MagicMock()
+        mock_payload.type = "refresh"
+        mock_payload.sub = str(user_id)
+        mock_payload.exp = datetime.now(UTC) + timedelta(days=7)
+
+        mock_user_repo.get_by_id = AsyncMock(return_value=mock_user)
+
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock),
+        ):
+            result = await auth_service.refresh_tokens("valid_refresh_token")
+
+        assert result.access_token is not None
+        assert result.refresh_token is not None
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_blacklisted(self, auth_service: AuthService) -> None:
+        """Test refresh fails when token is blacklisted."""
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            pytest.raises(InvalidTokenError, match="Token is blacklisted"),
+        ):
+            await auth_service.refresh_tokens("blacklisted_token")
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_invalid_token(
+        self, auth_service: AuthService
+    ) -> None:
+        """Test refresh fails with invalid token."""
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=None),
+            pytest.raises(InvalidTokenError, match="Invalid refresh token"),
+        ):
+            await auth_service.refresh_tokens("invalid_token")
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_wrong_token_type(
+        self, auth_service: AuthService
+    ) -> None:
+        """Test refresh fails when token type is not refresh."""
+        mock_payload = MagicMock()
+        mock_payload.type = "access"
+
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            pytest.raises(InvalidTokenError, match="Invalid refresh token"),
+        ):
+            await auth_service.refresh_tokens("access_token_not_refresh")
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_invalid_user_id(
+        self, auth_service: AuthService
+    ) -> None:
+        """Test refresh fails with invalid user ID in token."""
+        from datetime import UTC, datetime, timedelta
+
+        mock_payload = MagicMock()
+        mock_payload.type = "refresh"
+        mock_payload.sub = "not-a-valid-uuid"
+        mock_payload.exp = datetime.now(UTC) + timedelta(days=7)
+
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            pytest.raises(InvalidTokenError, match="Invalid token payload"),
+        ):
+            await auth_service.refresh_tokens("token_with_invalid_user_id")
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_user_not_found(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test refresh fails when user is not found."""
+        from datetime import UTC, datetime, timedelta
+
+        user_id = uuid4()
+        mock_payload = MagicMock()
+        mock_payload.type = "refresh"
+        mock_payload.sub = str(user_id)
+        mock_payload.exp = datetime.now(UTC) + timedelta(days=7)
+
+        mock_user_repo.get_by_id = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            pytest.raises(InvalidTokenError, match="User not found or inactive"),
+        ):
+            await auth_service.refresh_tokens("token_for_deleted_user")
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_inactive_user(
+        self, auth_service: AuthService, mock_user_repo: MagicMock
+    ) -> None:
+        """Test refresh fails when user is inactive."""
+        from datetime import UTC, datetime, timedelta
+
+        user_id = uuid4()
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user.is_active = False
+
+        mock_payload = MagicMock()
+        mock_payload.type = "refresh"
+        mock_payload.sub = str(user_id)
+        mock_payload.exp = datetime.now(UTC) + timedelta(days=7)
+
+        mock_user_repo.get_by_id = AsyncMock(return_value=mock_user)
+
+        with (
+            patch(
+                "app.services.auth.is_token_blacklisted",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("app.services.auth.decode_token", return_value=mock_payload),
+            pytest.raises(InvalidTokenError, match="User not found or inactive"),
+        ):
+            await auth_service.refresh_tokens("token_for_inactive_user")

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -17,9 +17,7 @@ class TestRegister:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test successful user registration."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             response = await client.post(
                 "/api/v1/auth/register",
                 json=test_user_data,
@@ -37,9 +35,7 @@ class TestRegister:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test registration with duplicate email."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             # Register first user
             await client.post(
                 "/api/v1/auth/register",
@@ -130,9 +126,7 @@ class TestLogin:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test successful login."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             # Register user first
             await client.post(
                 "/api/v1/auth/register",
@@ -160,9 +154,7 @@ class TestLogin:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test login with wrong password."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             # Register user first
             await client.post(
                 "/api/v1/auth/register",
@@ -209,7 +201,7 @@ class TestLogout:
     ) -> None:
         """Test successful logout."""
         with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
+            "app.services.auth.add_token_to_blacklist", new_callable=AsyncMock
         ) as mock_blacklist:
             # Register and get token
             register_response = await client.post(
@@ -249,11 +241,9 @@ class TestRefresh:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test successful token refresh."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             with patch(
-                "app.api.v1.endpoints.auth.is_token_blacklisted",
+                "app.services.auth.is_token_blacklisted",
                 new_callable=AsyncMock,
                 return_value=False,
             ):
@@ -282,7 +272,7 @@ class TestRefresh:
     ) -> None:
         """Test refresh with invalid token."""
         with patch(
-            "app.api.v1.endpoints.auth.is_token_blacklisted",
+            "app.services.auth.is_token_blacklisted",
             new_callable=AsyncMock,
             return_value=False,
         ):
@@ -299,9 +289,7 @@ class TestRefresh:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test refresh with blacklisted token."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             # Register and get tokens
             register_response = await client.post(
                 "/api/v1/auth/register",
@@ -311,7 +299,7 @@ class TestRefresh:
 
         # Mock blacklisted token
         with patch(
-            "app.api.v1.endpoints.auth.is_token_blacklisted",
+            "app.services.auth.is_token_blacklisted",
             new_callable=AsyncMock,
             return_value=True,
         ):
@@ -333,9 +321,7 @@ class TestGetCurrentUser:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test getting current user info."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             with patch(
                 "app.api.deps.is_token_blacklisted",
                 new_callable=AsyncMock,
@@ -394,9 +380,7 @@ class TestGetCurrentUser:
         test_user_data: dict[str, Any],
     ) -> None:
         """Test getting current user with blacklisted token."""
-        with patch(
-            "app.api.v1.endpoints.auth.add_token_to_blacklist", new_callable=AsyncMock
-        ):
+        with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
             # Register and get token
             register_response = await client.post(
                 "/api/v1/auth/register",


### PR DESCRIPTION
## Summary

- AuthServiceクラスを作成し、認証ビジネスロジックをエンドポイントから分離
- ドメイン固有の例外クラスを定義（EmailAlreadyExistsError, InvalidCredentialsError等）
- エンドポイントはHTTP処理と例外変換のみに責務を限定
- サービス層の単体テストを追加（17テストケース）

## Changes

### 新規ファイル
- `api/app/services/exceptions.py` - 共通例外クラス
- `api/app/services/auth.py` - AuthService
- `api/tests/services/test_auth.py` - サービス層テスト

### 変更ファイル
- `api/app/api/v1/endpoints/auth.py` - サービス層を使用するようリファクタリング
- `api/tests/test_auth.py` - モックパスを更新

## Architecture

```
Before: Endpoint → Repository → Database
After:  Endpoint → Service → Repository → Database
```

## Test plan

- [x] 全既存テストが通る（35/35）
- [x] サービス層テストカバレッジ 100%
- [x] 全体カバレッジ 91%
- [x] `ruff check` と `ruff format --check` が通る

Closes #62