### PR TITLE
feat: add dark mode toggle and improve header UI

### DIFF
--- a/web/app/[locale]/(main)/p/[projectSlug]/layout.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/layout.tsx
@@ -24,7 +24,7 @@ export default async function ProjectLayout({
   return (
     <div className="-mt-8">
       {/* Full-bleed: break out of container to span full viewport width */}
-      <div className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen">
+      <div className="relative right-1/2 left-1/2 -mr-[50vw] -ml-[50vw] w-screen">
         <ProjectTabs />
       </div>
       <div className="py-6">{children}</div>

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { routing } from '@/i18n/routing';
 import {
   QueryClientProvider,
   SessionProvider,
+  ThemeProvider,
 } from '@/shared/components/providers';
 import { Toaster } from '@/shared/components/ui/sonner';
 
@@ -38,12 +39,14 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider messages={messages}>
-      <SessionProvider>
-        <QueryClientProvider>
-          {children}
-          <Toaster richColors position="top-right" />
-        </QueryClientProvider>
-      </SessionProvider>
+      <ThemeProvider>
+        <SessionProvider>
+          <QueryClientProvider>
+            {children}
+            <Toaster richColors position="top-right" />
+          </QueryClientProvider>
+        </SessionProvider>
+      </ThemeProvider>
     </NextIntlClientProvider>
   );
 }

--- a/web/features/projects/components/ProjectTabs.tsx
+++ b/web/features/projects/components/ProjectTabs.tsx
@@ -76,7 +76,7 @@ export function ProjectTabs() {
                 key={tab.key}
                 href={tab.href}
                 className={cn(
-                  'group relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors',
+                  'group relative flex items-center gap-2 px-4 py-3 font-medium text-sm transition-colors',
                   active
                     ? 'text-zinc-900 dark:text-zinc-100'
                     : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -26,6 +26,7 @@
     "dashboard": "Dashboard",
     "projects": "Projects",
     "docs": "Documentation",
+    "edit": "Edit",
     "chat": "Chat",
     "admin": "Admin",
     "settings": "Settings",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -26,6 +26,7 @@
     "dashboard": "ダッシュボード",
     "projects": "プロジェクト",
     "docs": "ドキュメント",
+    "edit": "編集",
     "chat": "チャット",
     "admin": "管理",
     "settings": "設定",

--- a/web/shared/components/ThemeToggle.tsx
+++ b/web/shared/components/ThemeToggle.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { Button } from '@/shared/components/ui/button';
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 text-zinc-600 dark:text-zinc-400"
+        disabled
+      >
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    );
+  }
+
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="h-9 w-9 text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 rounded-full"
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}

--- a/web/shared/components/layout/Breadcrumb.tsx
+++ b/web/shared/components/layout/Breadcrumb.tsx
@@ -56,7 +56,7 @@ export function Breadcrumb() {
       else if (part === 'settings') label = t('settings');
       else if (part === 'users') label = t('users');
       else if (part === 'groups') label = t('groups');
-      else if (part === 'edit') label = t('docs');
+      else if (part === 'edit') label = t('edit');
       else if (part === 'models') label = 'Models';
 
       const prevPart = parts[i - 1];

--- a/web/shared/components/layout/Header.tsx
+++ b/web/shared/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/shared/components/ui/button';
 import { LanguageSwitcher } from '../LanguageSwitcher';
+import { ThemeToggle } from '../ThemeToggle';
 import { Breadcrumb } from './Breadcrumb';
 
 export function Header() {
@@ -22,14 +23,15 @@ export function Header() {
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Breadcrumb />
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           <LanguageSwitcher />
           <Button
             variant="ghost"
             size="sm"
             onClick={handleLogout}
-            className="gap-2 text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+            className="gap-2 text-zinc-600 hover:text-zinc-900 sm:min-w-32 sm:justify-start dark:text-zinc-400 dark:hover:text-zinc-100"
           >
-            <LogOut className="h-4 w-4" />
+            <LogOut className="h-4 w-4 shrink-0" />
             <span className="hidden sm:inline">{t('logout')}</span>
           </Button>
         </div>

--- a/web/shared/components/providers/ThemeProvider.tsx
+++ b/web/shared/components/providers/ThemeProvider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ComponentProps } from 'react';
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/web/shared/components/providers/index.ts
+++ b/web/shared/components/providers/index.ts
@@ -1,2 +1,3 @@
 export { QueryClientProvider } from './QueryClientProvider';
 export { SessionProvider } from './SessionProvider';
+export { ThemeProvider } from './ThemeProvider';

--- a/web/shared/components/ui/tabs.tsx
+++ b/web/shared/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 font-medium text-foreground text-sm transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:shadow-sm dark:text-muted-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Add dark mode toggle button to the header
- Add fixed width to logout button to prevent layout shift on language change
- Fix CSS class sorting order to comply with linter rules

## Test plan
- [x] Dark mode toggle button is displayed in the header
- [x] Clicking the button switches between light and dark modes
- [x] Logout button width remains stable when switching languages
- [x] Linter check passes