### PR TITLE
style: introduce warm theme color system with CSS variables

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -189,6 +189,41 @@ export function Button({ className, children }: ButtonProps) {
 }
 ```
 
+### Theme Colors
+
+**Always use CSS variable-based colors instead of hardcoded Tailwind colors.**
+
+Theme colors are defined in `app/globals.css` and automatically support light/dark mode.
+
+| Purpose | Use (✅) | Avoid (❌) |
+| ------- | -------- | ---------- |
+| Background | `bg-background`, `bg-card`, `bg-muted` | `bg-white`, `bg-zinc-50`, `bg-gray-100` |
+| Text | `text-foreground`, `text-muted-foreground` | `text-black`, `text-zinc-600`, `text-gray-500` |
+| Border | `border-border` | `border-zinc-200`, `border-gray-300` |
+| Primary | `bg-primary`, `text-primary` | Hardcoded brand colors |
+
+```tsx
+// ✅ Good - uses CSS variables
+<div className="bg-background text-foreground">
+  <p className="text-muted-foreground">Secondary text</p>
+</div>
+
+// ❌ Bad - hardcoded colors don't respect theme
+<div className="bg-white text-black dark:bg-zinc-900 dark:text-white">
+  <p className="text-gray-600 dark:text-gray-400">Secondary text</p>
+</div>
+```
+
+**Available CSS variable colors:**
+- `background`, `foreground` - Main background/text
+- `card`, `card-foreground` - Card surfaces
+- `muted`, `muted-foreground` - Muted surfaces/secondary text
+- `primary`, `primary-foreground` - Primary actions
+- `secondary`, `secondary-foreground` - Secondary actions
+- `accent`, `accent-foreground` - Accent highlights
+- `border`, `input`, `ring` - Borders and focus states
+- `destructive` - Destructive actions (delete, etc.)
+
 ### Server Components vs Client Components
 
 ```tsx
@@ -534,6 +569,7 @@ import { useTranslations } from 'next-intl';
 ### Prohibited
 
 - Hardcoding UI text (use translation files)
+- Hardcoding colors (use CSS variables like `bg-background`, `text-foreground`)
 - Using `any` type
 - Adding unnecessary `'use client'`
 - Merging without tests

--- a/web/app/[locale]/(main)/admin/groups/page.tsx
+++ b/web/app/[locale]/(main)/admin/groups/page.tsx
@@ -18,7 +18,7 @@ function GroupsContent() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="font-bold text-3xl">{t('title')}</h1>
-      <p className="mt-4 text-gray-600">{t('list')}</p>
+      <p className="mt-4 text-muted-foreground">{t('list')}</p>
       {/* TODO: グループ一覧と管理機能を実装 */}
     </div>
   );

--- a/web/app/[locale]/(main)/admin/page.tsx
+++ b/web/app/[locale]/(main)/admin/page.tsx
@@ -18,7 +18,7 @@ function AdminContent() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="font-bold text-3xl">{t('title')}</h1>
-      <p className="mt-4 text-gray-600">{t('title')}</p>
+      <p className="mt-4 text-muted-foreground">{t('title')}</p>
       {/* TODO: 管理ダッシュボードを実装 */}
     </div>
   );

--- a/web/app/[locale]/(main)/admin/users/page.tsx
+++ b/web/app/[locale]/(main)/admin/users/page.tsx
@@ -18,7 +18,7 @@ function UsersContent() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="font-bold text-3xl">{t('title')}</h1>
-      <p className="mt-4 text-gray-600">{t('list')}</p>
+      <p className="mt-4 text-muted-foreground">{t('list')}</p>
       {/* TODO: ユーザー一覧と管理機能を実装 */}
     </div>
   );

--- a/web/app/[locale]/(main)/layout.tsx
+++ b/web/app/[locale]/(main)/layout.tsx
@@ -6,7 +6,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-screen bg-background">
       <Header />
       <PageContainer>{children}</PageContainer>
     </div>

--- a/web/app/[locale]/(main)/p/[projectSlug]/chat/[conversationId]/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/chat/[conversationId]/page.tsx
@@ -45,7 +45,7 @@ function ConversationContent({
         <h1 className="font-bold text-xl">
           {projectSlug} {t('title')}
         </h1>
-        <p className="text-gray-500 text-sm">ID: {conversationId}</p>
+        <p className="text-muted-foreground text-sm">ID: {conversationId}</p>
       </header>
       <main className="flex-1 overflow-auto p-4">
         {/* TODO: Implement chat message display */}

--- a/web/app/[locale]/(main)/p/[projectSlug]/chat/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/chat/page.tsx
@@ -26,7 +26,7 @@ function ChatContent({ projectSlug }: { projectSlug: string }) {
         </h1>
       </header>
       <main className="flex-1 overflow-auto p-4">
-        <p className="text-gray-600">{t('newConversation')}</p>
+        <p className="text-muted-foreground">{t('newConversation')}</p>
         {/* TODO: Implement conversation list and chat interface */}
       </main>
     </div>

--- a/web/app/[locale]/(main)/p/[projectSlug]/docs/[...docPath]/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/docs/[...docPath]/page.tsx
@@ -36,7 +36,7 @@ function DocContent({
 
   return (
     <div>
-      <nav className="mb-4 text-gray-500 text-sm">
+      <nav className="mb-4 text-muted-foreground text-sm">
         {projectSlug} / {path}
       </nav>
       <article className="prose max-w-none">

--- a/web/app/[locale]/(main)/p/[projectSlug]/docs/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/docs/page.tsx
@@ -25,7 +25,7 @@ function ProjectDocsContent({ projectSlug }: { projectSlug: string }) {
       <h1 className="font-bold text-3xl">
         {projectSlug} {t('docs.title')}
       </h1>
-      <p className="mt-4 text-gray-600">{t('docs.noDocs')}</p>
+      <p className="mt-4 text-muted-foreground">{t('docs.noDocs')}</p>
       {/* TODO: Implement document list */}
     </div>
   );

--- a/web/app/[locale]/(main)/p/[projectSlug]/edit/[...docPath]/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/edit/[...docPath]/page.tsx
@@ -36,11 +36,11 @@ function EditDocContent({
 
   return (
     <div>
-      <nav className="mb-4 text-gray-500 text-sm">
+      <nav className="mb-4 text-muted-foreground text-sm">
         {projectSlug} / {path}
       </nav>
       <h1 className="font-bold text-3xl">{t('edit')}</h1>
-      <p className="mt-4 text-gray-600">{path}</p>
+      <p className="mt-4 text-muted-foreground">{path}</p>
       {/* TODO: Implement document editor */}
     </div>
   );

--- a/web/app/[locale]/(main)/p/[projectSlug]/edit/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/edit/page.tsx
@@ -23,7 +23,7 @@ function EditProjectContent({ projectSlug }: { projectSlug: string }) {
   return (
     <div>
       <h1 className="font-bold text-3xl">{t('common.edit')}</h1>
-      <p className="mt-4 text-gray-600">{projectSlug}</p>
+      <p className="mt-4 text-muted-foreground">{projectSlug}</p>
       {/* TODO: Implement project edit form */}
     </div>
   );

--- a/web/app/[locale]/(main)/personal/page.tsx
+++ b/web/app/[locale]/(main)/personal/page.tsx
@@ -25,7 +25,7 @@ function PersonalContent() {
   return (
     <div>
       <h1 className="font-bold text-3xl">{t('title')}</h1>
-      <p className="mt-4 text-gray-600">{t('description')}</p>
+      <p className="mt-4 text-muted-foreground">{t('description')}</p>
       {/* TODO: Implement personal settings */}
     </div>
   );

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -48,71 +48,73 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  /* Medium-style warm paper theme */
+  --background: oklch(0.985 0.008 85);
   --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
+  --card: oklch(0.99 0.006 85);
   --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.99 0.006 85);
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
+  --primary-foreground: oklch(0.985 0.008 85);
+  --secondary: oklch(0.97 0.008 85);
   --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
+  --muted: oklch(0.97 0.008 85);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
+  --accent: oklch(0.97 0.008 85);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
+  --border: oklch(0.92 0.01 85);
+  --input: oklch(0.92 0.01 85);
   --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
+  --sidebar: oklch(0.975 0.01 85);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0.008 85);
+  --sidebar-accent: oklch(0.97 0.008 85);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-border: oklch(0.92 0.01 85);
   --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  /* Warm dark theme - matches light theme warmth */
+  --background: oklch(0.18 0.01 75);
+  --foreground: oklch(0.93 0.01 85);
+  --card: oklch(0.22 0.012 75);
+  --card-foreground: oklch(0.93 0.01 85);
+  --popover: oklch(0.22 0.012 75);
+  --popover-foreground: oklch(0.93 0.01 85);
+  --primary: oklch(0.93 0.01 85);
+  --primary-foreground: oklch(0.22 0.012 75);
+  --secondary: oklch(0.28 0.015 75);
+  --secondary-foreground: oklch(0.93 0.01 85);
+  --muted: oklch(0.28 0.015 75);
+  --muted-foreground: oklch(0.65 0.01 75);
+  --accent: oklch(0.28 0.015 75);
+  --accent-foreground: oklch(0.93 0.01 85);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --border: oklch(0.35 0.015 75);
+  --input: oklch(0.30 0.015 75);
+  --ring: oklch(0.5 0.01 75);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.16 0.012 75);
+  --sidebar-foreground: oklch(0.93 0.01 85);
+  --sidebar-primary: oklch(0.7 0.15 75);
+  --sidebar-primary-foreground: oklch(0.93 0.01 85);
+  --sidebar-accent: oklch(0.28 0.015 75);
+  --sidebar-accent-foreground: oklch(0.93 0.01 85);
+  --sidebar-border: oklch(0.35 0.015 75);
+  --sidebar-ring: oklch(0.5 0.01 75);
 }
 
 @layer base {

--- a/web/features/projects/components/ProjectTabs.tsx
+++ b/web/features/projects/components/ProjectTabs.tsx
@@ -64,7 +64,7 @@ export function ProjectTabs() {
   };
 
   return (
-    <nav className="border-zinc-200 border-b bg-white dark:border-zinc-800 dark:bg-zinc-950">
+    <nav className="border-border border-b bg-card">
       <div className="container mx-auto px-4">
         <div className="-mb-px flex gap-1">
           {tabs.map((tab) => {
@@ -78,16 +78,16 @@ export function ProjectTabs() {
                 className={cn(
                   'group relative flex items-center gap-2 px-4 py-3 font-medium text-sm transition-colors',
                   active
-                    ? 'text-zinc-900 dark:text-zinc-100'
-                    : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
                 )}
               >
                 <Icon
                   className={cn(
                     'h-4 w-4 transition-colors',
                     active
-                      ? 'text-zinc-700 dark:text-zinc-300'
-                      : 'text-zinc-400 group-hover:text-zinc-500 dark:text-zinc-500 dark:group-hover:text-zinc-400'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground group-hover:text-foreground'
                   )}
                 />
                 <span>{t(tab.labelKey)}</span>
@@ -97,8 +97,8 @@ export function ProjectTabs() {
                   className={cn(
                     'absolute inset-x-0 -bottom-px h-0.5 rounded-full transition-all',
                     active
-                      ? 'bg-zinc-900 dark:bg-zinc-100'
-                      : 'bg-transparent group-hover:bg-zinc-300 dark:group-hover:bg-zinc-700'
+                      ? 'bg-foreground'
+                      : 'bg-transparent group-hover:bg-border'
                   )}
                 />
               </Link>

--- a/web/shared/components/ThemeToggle.tsx
+++ b/web/shared/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
       <Button
         variant="ghost"
         size="icon"
-        className="h-9 w-9 text-zinc-600 dark:text-zinc-400"
+        className="h-9 w-9 text-muted-foreground"
         disabled
       >
         <Sun className="h-4 w-4" />
@@ -36,7 +36,7 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       onClick={toggleTheme}
-      className="h-9 w-9 rounded-full text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+      className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
     >
       {theme === 'dark' ? (
         <Sun className="h-4 w-4" />

--- a/web/shared/components/layout/Header.tsx
+++ b/web/shared/components/layout/Header.tsx
@@ -19,7 +19,7 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-40 w-full border-zinc-200 border-b bg-white/80 backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-950/80">
+    <header className="sticky top-0 z-40 w-full border-border border-b bg-card/80 backdrop-blur-sm">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Breadcrumb />
         <div className="flex items-center gap-2">
@@ -29,7 +29,7 @@ export function Header() {
             variant="ghost"
             size="sm"
             onClick={handleLogout}
-            className="gap-2 text-zinc-600 hover:text-zinc-900 sm:min-w-32 sm:justify-start dark:text-zinc-400 dark:hover:text-zinc-100"
+            className="gap-2 text-muted-foreground hover:text-foreground sm:min-w-32 sm:justify-start"
           >
             <LogOut className="h-4 w-4 shrink-0" />
             <span className="hidden sm:inline">{t('logout')}</span>


### PR DESCRIPTION
## Summary
- Update light theme to warm cream colors (hue 85°) for a paper-like feel
- Update dark theme to warm brown-dark colors (hue 75°) for consistency
- Replace all hardcoded colors with CSS variables for proper theme support
- Add theme color guidelines to AGENTS.md to prevent future hardcoding

## Test plan
- [x] Verify light theme displays warm cream colors
- [x] Verify dark theme displays warm brown-dark colors
- [x] Toggle between light/dark themes and confirm all elements change color correctly
- [x] Check AGENTS.md for new theme color guidelines

Closes #81