### PR TITLE
style: adjust layout padding for full-width header and content

### DIFF
--- a/web/app/[locale]/(main)/p/[projectSlug]/layout.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/layout.tsx
@@ -22,12 +22,9 @@ export default async function ProjectLayout({
   }
 
   return (
-    <div className="-mt-8">
-      {/* Full-bleed: break out of container to span full viewport width */}
-      <div className="relative right-1/2 left-1/2 -mr-[50vw] -ml-[50vw] w-screen">
-        <ProjectTabs />
-      </div>
-      <div className="py-6">{children}</div>
+    <div className="-my-8">
+      <ProjectTabs />
+      <div className="py-8">{children}</div>
     </div>
   );
 }

--- a/web/features/projects/components/ProjectTabs.tsx
+++ b/web/features/projects/components/ProjectTabs.tsx
@@ -64,8 +64,8 @@ export function ProjectTabs() {
   };
 
   return (
-    <nav className="border-border border-b bg-card">
-      <div className="container mx-auto px-4">
+    <nav className="-mx-6 border-border border-b bg-card">
+      <div className="px-6">
         <div className="-mb-px flex gap-1">
           {tabs.map((tab) => {
             const Icon = tab.icon;

--- a/web/shared/components/layout/Header.tsx
+++ b/web/shared/components/layout/Header.tsx
@@ -7,7 +7,7 @@ import { Breadcrumb } from './Breadcrumb';
 export function Header() {
   return (
     <header className="sticky top-0 z-40 w-full border-border border-b bg-card/80 backdrop-blur-sm">
-      <div className="container mx-auto flex h-14 items-center justify-between px-4">
+      <div className="flex h-14 items-center justify-between px-6">
         <Breadcrumb />
         <div className="flex items-center gap-2">
           <ThemeToggle />

--- a/web/shared/components/layout/PageContainer.tsx
+++ b/web/shared/components/layout/PageContainer.tsx
@@ -5,5 +5,5 @@ interface PageContainerProps {
 }
 
 export function PageContainer({ children }: PageContainerProps) {
-  return <main className="container mx-auto px-4 py-8">{children}</main>;
+  return <main className="px-6 py-8">{children}</main>;
 }


### PR DESCRIPTION
## Summary
- Remove container max-width from Header, PageContainer, and ProjectTabs
- Use `px-6` padding for consistent spacing
- Use negative margin on ProjectTabs to achieve full-width background
- Remove full-bleed hack from ProjectLayout

## Test plan
- [x] Verify Header displays with proper padding
- [x] Verify main content has appropriate padding
- [x] Verify ProjectTabs spans full width while maintaining aligned tab content
- [x] Verify layout works correctly with Activity Bar sidebar

Closes #109