### PR TITLE
feat: add user profile update API endpoint

### DIFF
--- a/api/app/api/v1/endpoints/users.py
+++ b/api/app/api/v1/endpoints/users.py
@@ -1,0 +1,36 @@
+"""Users API endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.core.database import get_db
+from app.models.user import User
+from app.repositories.user import UserRepository
+from app.schemas.user import UserProfileUpdate, UserRead
+from app.services.user import UserService
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_user_service(db: Annotated[AsyncSession, Depends(get_db)]) -> UserService:
+    """Dependency to get UserService."""
+    return UserService(UserRepository(db))
+
+
+@router.patch("/me", response_model=UserRead)
+async def update_my_profile(
+    data: UserProfileUpdate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[UserService, Depends(get_user_service)],
+) -> User:
+    """Update current user's profile.
+
+    Allows updating:
+    - name: Display name (1-100 characters)
+    - avatar_url: URL to avatar image (max 500 characters)
+    - preferred_locale: Preferred locale code (2-10 characters, e.g., "en", "ja")
+    """
+    return await service.update_profile(current_user.id, data)

--- a/api/app/api/v1/router.py
+++ b/api/app/api/v1/router.py
@@ -2,7 +2,14 @@
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, documents, health, project_members, projects
+from app.api.v1.endpoints import (
+    auth,
+    documents,
+    health,
+    project_members,
+    projects,
+    users,
+)
 
 api_router = APIRouter()
 
@@ -11,6 +18,9 @@ api_router.include_router(health.router, tags=["health"])
 
 # Include auth endpoints
 api_router.include_router(auth.router)
+
+# Include users endpoints
+api_router.include_router(users.router)
 
 # Include projects endpoints
 api_router.include_router(projects.router)

--- a/api/app/repositories/user.py
+++ b/api/app/repositories/user.py
@@ -1,5 +1,6 @@
 """User repository for database operations."""
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
@@ -81,3 +82,20 @@ class UserRepository:
         """
         user = await self.get_by_email(email)
         return user is not None
+
+    async def update(self, user: User, data: dict[str, Any]) -> User:
+        """Update user with given data.
+
+        Args:
+            user: The user to update.
+            data: Dictionary of fields to update.
+
+        Returns:
+            The updated user.
+        """
+        for key, value in data.items():
+            if hasattr(user, key):
+                setattr(user, key, value)
+        await self.db.commit()
+        await self.db.refresh(user)
+        return user

--- a/api/app/schemas/user.py
+++ b/api/app/schemas/user.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class UserBase(BaseModel):
@@ -21,7 +21,7 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    """Schema for updating a user."""
+    """Schema for updating a user (admin use)."""
 
     email: EmailStr | None = None
     name: str | None = None
@@ -30,6 +30,16 @@ class UserUpdate(BaseModel):
     is_active: bool | None = None
     api_limit: int | None = None
     preferred_locale: str | None = None
+
+
+class UserProfileUpdate(BaseModel):
+    """Schema for user self-profile update."""
+
+    name: str | None = Field(None, min_length=1, max_length=100)
+    avatar_url: str | None = Field(None, max_length=500)
+    preferred_locale: str | None = Field(None, min_length=2, max_length=10)
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserRead(UserBase):

--- a/api/app/services/user.py
+++ b/api/app/services/user.py
@@ -1,0 +1,60 @@
+"""User service for user operations."""
+
+from uuid import UUID
+
+from app.models.user import User
+from app.repositories.user import UserRepository
+from app.schemas.user import UserProfileUpdate
+from app.services.exceptions import UserNotFoundError
+
+
+class UserService:
+    """Service for user operations."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        """Initialize the service with a user repository.
+
+        Args:
+            user_repo: The user repository instance.
+        """
+        self.user_repo = user_repo
+
+    async def get_by_id(self, user_id: UUID) -> User:
+        """Get user by ID.
+
+        Args:
+            user_id: The UUID of the user.
+
+        Returns:
+            The user.
+
+        Raises:
+            UserNotFoundError: If user is not found.
+        """
+        user = await self.user_repo.get_by_id(user_id)
+        if not user:
+            raise UserNotFoundError(f"User {user_id} not found")
+        return user
+
+    async def update_profile(self, user_id: UUID, data: UserProfileUpdate) -> User:
+        """Update user profile with allowed fields only.
+
+        Args:
+            user_id: The UUID of the user.
+            data: The profile update data.
+
+        Returns:
+            The updated user.
+
+        Raises:
+            UserNotFoundError: If user is not found.
+        """
+        user = await self.get_by_id(user_id)
+
+        # Only update fields that were provided (not None)
+        update_data = data.model_dump(exclude_unset=True)
+
+        if not update_data:
+            return user  # Nothing to update
+
+        return await self.user_repo.update(user, update_data)

--- a/api/tests/integration/api/test_users.py
+++ b/api/tests/integration/api/test_users.py
@@ -1,0 +1,197 @@
+"""Tests for user profile endpoints."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture
+async def auth_headers(
+    client: AsyncClient, test_user_data: dict[str, Any]
+) -> dict[str, str]:
+    """Register a user and return auth headers."""
+    with patch("app.services.auth.add_token_to_blacklist", new_callable=AsyncMock):
+        response = await client.post("/api/v1/auth/register", json=test_user_data)
+        access_token = response.json()["access_token"]
+        return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.mark.asyncio
+class TestUpdateMyProfile:
+    """Tests for PATCH /api/v1/users/me."""
+
+    async def test_update_profile_success(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test successfully updating all profile fields."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={
+                    "name": "Updated Name",
+                    "avatar_url": "https://example.com/avatar.png",
+                    "preferred_locale": "ja",
+                },
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Name"
+        assert data["avatar_url"] == "https://example.com/avatar.png"
+        assert data["preferred_locale"] == "ja"
+
+    async def test_update_profile_partial_update(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test updating only some fields."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            # Update only name
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"name": "New Name Only"},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "New Name Only"
+
+    async def test_update_profile_empty_body(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test updating with empty body returns current user."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        # User data should be returned unchanged
+
+    async def test_update_profile_unauthorized(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test updating profile without auth."""
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"name": "New Name"},
+        )
+        assert response.status_code == 401  # No auth header
+
+    async def test_update_profile_invalid_token(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Test updating profile with invalid token."""
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"name": "New Name"},
+            headers={"Authorization": "Bearer invalid_token"},
+        )
+        assert response.status_code == 401
+
+    async def test_update_profile_name_too_short(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test validation error for name that is too short."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"name": ""},  # Empty name
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 422
+
+    async def test_update_profile_name_too_long(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test validation error for name that is too long."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"name": "x" * 101},  # 101 characters
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 422
+
+    async def test_update_profile_locale_too_short(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test validation error for locale that is too short."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"preferred_locale": "x"},  # 1 character
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 422
+
+    async def test_update_profile_preserves_other_fields(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_user_data: dict[str, Any],
+    ) -> None:
+        """Test that updating profile preserves other user fields."""
+        with patch(
+            "app.api.deps.is_token_blacklisted",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"name": "New Name"},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Email should remain unchanged
+        assert data["email"] == test_user_data["email"]
+        # is_active should remain True
+        assert data["is_active"] is True


### PR DESCRIPTION
## Summary

- Add `PATCH /api/v1/users/me` endpoint for users to update their profile
- Allows updating: `name`, `avatar_url`, `preferred_locale`
- Includes validation: name (1-100 chars), avatar_url (max 500 chars), preferred_locale (2-10 chars)

## Changes

- Add `UserProfileUpdate` schema with field validation
- Add `update()` method to `UserRepository`
- Create `UserService` with `update_profile()` method
- Create `users.py` endpoint with `PATCH /me` route
- Add 9 integration tests for profile update

## Test plan

- [x] Run integration tests: `pytest tests/integration/api/test_users.py -v`
- [x] All 139 tests pass
- [x] Lint check passes

Closes #105

🤖 Generated with [Claude Code](https://claude.ai/code)