### PR TITLE
fix: include member and public projects in project list

### DIFF
--- a/api/app/api/v1/endpoints/projects.py
+++ b/api/app/api/v1/endpoints/projects.py
@@ -53,7 +53,12 @@ async def list_projects(
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=100)] = 100,
 ) -> list[ProjectRead]:
-    """List all projects owned by the current user.
+    """List all projects accessible by the current user.
+
+    Includes:
+    - Projects owned by the user
+    - Projects where user is a member
+    - Public projects
 
     Args:
         current_user: The authenticated user.
@@ -62,9 +67,9 @@ async def list_projects(
         limit: Maximum number of records to return.
 
     Returns:
-        List of projects owned by the current user.
+        List of accessible projects.
     """
-    projects = await project_service.get_projects_by_owner(
+    projects = await project_service.get_accessible_projects(
         current_user.id, skip=skip, limit=limit
     )
     return [ProjectRead.model_validate(p) for p in projects]

--- a/api/app/services/project.py
+++ b/api/app/services/project.py
@@ -77,6 +77,26 @@ class ProjectService:
         """
         return await self.project_repo.get_by_owner(owner_id, skip, limit)
 
+    async def get_accessible_projects(
+        self, user_id: UUID, skip: int = 0, limit: int = 100
+    ) -> list[Project]:
+        """Get all projects accessible by a user.
+
+        Includes:
+        - Projects owned by the user
+        - Projects where user is a member
+        - Public projects
+
+        Args:
+            user_id: The UUID of the user.
+            skip: Number of records to skip (pagination).
+            limit: Maximum number of records to return.
+
+        Returns:
+            List of accessible projects.
+        """
+        return await self.project_repo.get_accessible_projects(user_id, skip, limit)
+
     async def update_project(
         self, slug: str, update_data: ProjectUpdate, user_id: UUID
     ) -> Project:


### PR DESCRIPTION
## Summary

Update `GET /api/v1/projects` to return all accessible projects:
- Projects owned by the user
- Projects where user is a member (viewer/editor/admin)
- Public projects

## Permission Matrix

| Project Type | User Relationship | Include in List? |
|-------------|------------------|-----------------|
| **public** | Anyone | ✅ |
| **private** | Owner | ✅ |
| **private** | Member | ✅ |
| **private** | Unrelated | ❌ |

## Changes

- Add `get_accessible_projects()` to `ProjectRepository` using OR query with DISTINCT
- Add `get_accessible_projects()` to `ProjectService`
- Update `list_projects()` endpoint to use new method
- Add 3 integration tests for new behavior

## Test plan

- [x] Run project tests: `pytest tests/integration/api/test_projects.py -v` (19 passed)
- [x] All 142 tests pass
- [x] Lint check passes

Closes #114