### PR TITLE
fix: show 404 Not Found page for non-existent projects

### DIFF
--- a/web/features/projects/components/PermissionGuard.tsx
+++ b/web/features/projects/components/PermissionGuard.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 
-import { ForbiddenPage } from '@/shared/components';
+import { ForbiddenPage, NotFoundPage } from '@/shared/components';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
 import { type Permission, useProjectPermissions } from '../hooks';
@@ -22,6 +22,7 @@ interface PermissionGuardProps {
  * Guard component that checks user permission before rendering children.
  *
  * Shows a loading skeleton while permissions are being fetched.
+ * Shows a 404 Not Found page if the project doesn't exist.
  * Shows a 403 Forbidden page if the user lacks the required permission.
  * Renders children if the user has the required permission.
  *
@@ -38,13 +39,19 @@ export function PermissionGuard({
   children,
   fallback,
 }: PermissionGuardProps) {
-  const { hasPermission, isLoading, error } =
+  const { hasPermission, isLoading, error, isNotFound } =
     useProjectPermissions(projectSlug);
 
   if (isLoading) {
     return fallback ?? <LoadingSkeleton />;
   }
 
+  // Show 404 page if project doesn't exist
+  if (isNotFound) {
+    return <NotFoundPage />;
+  }
+
+  // Show 403 page for other errors or lack of permission
   if (error || !hasPermission(requiredPermission)) {
     return <ForbiddenPage />;
   }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -173,7 +173,8 @@
     "noNotificationsDescription": "You're all caught up! New notifications will appear here."
   },
   "errors": {
-    "notFound": "Page not found",
+    "notFound": "Not Found",
+    "notFoundDescription": "The resource you are looking for does not exist or has been removed.",
     "unauthorized": "Authentication required",
     "forbidden": "Access denied",
     "forbiddenDescription": "You don't have permission to view this page. Please contact the project administrator.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -173,7 +173,8 @@
     "noNotificationsDescription": "新しい通知はここに表示されます。"
   },
   "errors": {
-    "notFound": "ページが見つかりませんでした",
+    "notFound": "見つかりません",
+    "notFoundDescription": "お探しのリソースは存在しないか、削除された可能性があります。",
     "unauthorized": "認証が必要です",
     "forbidden": "アクセス権限がありません",
     "forbiddenDescription": "このページを表示する権限がありません。プロジェクト管理者にお問い合わせください。",

--- a/web/shared/components/NotFoundPage.tsx
+++ b/web/shared/components/NotFoundPage.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { FileQuestion } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/shared/components/ui/button';
+
+interface NotFoundPageProps {
+  /** Custom back URL. Defaults to project list. */
+  backHref?: string;
+}
+
+/**
+ * 404 Not Found page component.
+ *
+ * Displays a not found message with a button to navigate back.
+ * Used when a user tries to access a resource that doesn't exist.
+ */
+export function NotFoundPage({ backHref }: NotFoundPageProps) {
+  const t = useTranslations('errors');
+  const params = useParams();
+  const locale = params.locale as string;
+
+  const defaultBackHref = `/${locale}/projects`;
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center text-center">
+      <FileQuestion className="h-16 w-16 text-muted-foreground" />
+      <h1 className="mt-6 font-bold text-2xl">{t('notFound')}</h1>
+      <p className="mt-2 max-w-md text-muted-foreground">
+        {t('notFoundDescription')}
+      </p>
+      <Button asChild className="mt-6">
+        <Link href={backHref ?? defaultBackHref}>{t('backToProjects')}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/web/shared/components/__tests__/NotFoundPage.test.tsx
+++ b/web/shared/components/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NotFoundPage } from '@/shared/components/NotFoundPage';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'en' }),
+}));
+
+const messages = {
+  errors: {
+    notFound: 'Not Found',
+    notFoundDescription:
+      'The resource you are looking for does not exist or has been removed.',
+    backToProjects: 'Back to Projects',
+  },
+};
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <NextIntlClientProvider locale="en" messages={messages}>
+        {children}
+      </NextIntlClientProvider>
+    );
+  };
+}
+
+describe('NotFoundPage', () => {
+  it('should render not found message', () => {
+    render(<NotFoundPage />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Not Found')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The resource you are looking for does not exist or has been removed.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should have default back link to projects', () => {
+    render(<NotFoundPage />, { wrapper: createWrapper() });
+
+    const link = screen.getByRole('link', { name: 'Back to Projects' });
+    expect(link).toHaveAttribute('href', '/en/projects');
+  });
+
+  it('should support custom back href', () => {
+    render(<NotFoundPage backHref="/custom/path" />, {
+      wrapper: createWrapper(),
+    });
+
+    const link = screen.getByRole('link', { name: 'Back to Projects' });
+    expect(link).toHaveAttribute('href', '/custom/path');
+  });
+
+  it('should render icon', () => {
+    const { container } = render(<NotFoundPage />, {
+      wrapper: createWrapper(),
+    });
+
+    // Check that an SVG icon is rendered
+    const icon = container.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/web/shared/components/index.ts
+++ b/web/shared/components/index.ts
@@ -1,4 +1,5 @@
 export { BookmarkButton } from './BookmarkButton';
 export { ForbiddenPage } from './ForbiddenPage';
 export { LanguageSwitcher } from './LanguageSwitcher';
+export { NotFoundPage } from './NotFoundPage';
 export { ProjectCard } from './ProjectCard';

--- a/web/shared/lib/api/errors.ts
+++ b/web/shared/lib/api/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * API Error class that preserves HTTP status code.
+ * Used to distinguish between different error types (404, 403, etc.)
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly detail?: unknown
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  get isNotFound(): boolean {
+    return this.status === 404;
+  }
+
+  get isForbidden(): boolean {
+    return this.status === 403;
+  }
+
+  get isUnauthorized(): boolean {
+    return this.status === 401;
+  }
+
+  get isClientError(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+
+  get isServerError(): boolean {
+    return this.status >= 500;
+  }
+}
+
+/**
+ * Type guard to check if an error is an ApiError.
+ */
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}


### PR DESCRIPTION
## Summary
- Show 404 Not Found instead of 403 Forbidden when accessing non-existent projects
- Skip TanStack Query retries for 4xx client errors to eliminate response delay

## Changes
- Add `ApiError` class to preserve HTTP status codes from API responses
- Add error interceptor to wrap errors with `ApiError`
- Create `NotFoundPage` component for 404 errors
- Add `isNotFound` flag to `useProjectPermissions` hook
- Update `PermissionGuard` to show `NotFoundPage` for 404 errors

## Test plan
- [x] Navigate to `/p/non-existent-project` and verify 404 page is displayed
- [x] Verify no retry delay for 404 errors
- [x] Verify 403 page is shown for projects without permission
- [x] All tests pass (`npm test -- --run`)

Closes #119