### PR TITLE
fix: only cache setup status when setup is completed

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -20,8 +20,11 @@ const CACHE_TTL = 60 * 1000; // 1 minute cache
  * Check if setup is completed
  */
 async function isSetupCompleted(): Promise<boolean> {
-  // Return cached value if still valid
-  if (setupStatusCache && Date.now() - setupStatusCache.timestamp < CACHE_TTL) {
+  // Return cached value if still valid (only cache when setup is completed)
+  if (
+    setupStatusCache?.isCompleted &&
+    Date.now() - setupStatusCache.timestamp < CACHE_TTL
+  ) {
     return setupStatusCache.isCompleted;
   }
 


### PR DESCRIPTION
## Summary
- Fix issue where setup completion might not immediately redirect to `/login` due to cached `isCompleted: false` value
- Only use cache when `isCompleted` is `true`, ensuring setup completion is immediately reflected

## Test plan
- [ ] Clear DB and start application
- [ ] Access `/` → should redirect to `/setup`
- [ ] Create admin → should immediately redirect to `/login` (not wait up to 1 minute)
- [ ] Login → should access dashboard