### PR TITLE
refactor(web): unify EmptyState component across Dashboard and Projects

### DIFF
--- a/web/features/dashboard/components/RecentProjects.tsx
+++ b/web/features/dashboard/components/RecentProjects.tsx
@@ -1,43 +1,21 @@
 'use client';
 
-import { FolderPlus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { ProjectCard } from '@/features/projects/components/ProjectCard';
 import { useProjectListSuspense } from '@/features/projects/hooks/useProjects';
-import { Link } from '@/i18n/routing';
-import { Button } from '@/shared/components/ui/button';
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/shared/components/ui/card';
+import { EmptyProjects } from '@/shared/components';
 
 /**
  * Recent projects list component using Suspense.
  * Must be wrapped in Suspense boundary and data should be prefetched on server.
  */
 export function RecentProjects() {
-  const t = useTranslations('dashboard');
   const tProjects = useTranslations('projects');
   const { data: projects } = useProjectListSuspense(0, 3);
 
   if (!projects || projects.length === 0) {
-    return (
-      <Card className="border-dashed">
-        <CardHeader className="text-center">
-          <FolderPlus className="mx-auto h-12 w-12 text-muted-foreground" />
-          <CardTitle className="text-lg">{tProjects('noProjects')}</CardTitle>
-          <CardDescription>{t('createFirstProject')}</CardDescription>
-          <div className="pt-4">
-            <Button asChild>
-              <Link href="/projects">{tProjects('new')}</Link>
-            </Button>
-          </div>
-        </CardHeader>
-      </Card>
-    );
+    return <EmptyProjects action={{ type: 'link', href: '/projects' }} />;
   }
 
   return (

--- a/web/features/projects/components/ProjectList.tsx
+++ b/web/features/projects/components/ProjectList.tsx
@@ -2,22 +2,28 @@
 
 import { useTranslations } from 'next-intl';
 
+import { EmptyProjects } from '@/shared/components';
+
 import { useProjectListSuspense } from '../hooks/useProjects';
 import { ProjectCard } from './ProjectCard';
+
+interface ProjectListProps {
+  onCreateClick?: () => void;
+}
 
 /**
  * Project list component using Suspense.
  * Must be wrapped in a Suspense boundary and data should be prefetched on the server.
  */
-export function ProjectList() {
+export function ProjectList({ onCreateClick }: ProjectListProps) {
   const t = useTranslations('projects');
   const { data: projects } = useProjectListSuspense();
 
   if (!projects || projects.length === 0) {
-    return (
-      <div className="py-8 text-center text-muted-foreground">
-        {t('noProjects')}
-      </div>
+    return onCreateClick ? (
+      <EmptyProjects action={{ type: 'button', onClick: onCreateClick }} />
+    ) : (
+      <EmptyProjects action={{ type: 'link', href: '/projects' }} />
     );
   }
 

--- a/web/features/projects/components/ProjectsPageContent.tsx
+++ b/web/features/projects/components/ProjectsPageContent.tsx
@@ -45,7 +45,7 @@ export function ProjectsPageContent() {
       </div>
       <ErrorBoundary fallback={<ProjectListError />}>
         <Suspense fallback={<ProjectListSkeleton />}>
-          <ProjectList />
+          <ProjectList onCreateClick={() => setIsDialogOpen(true)} />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/web/shared/components/EmptyProjects.tsx
+++ b/web/shared/components/EmptyProjects.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { FolderPlus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { Link } from '@/i18n/routing';
+import { cn } from '@/shared/lib/utils';
+
+import { Button } from './ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from './ui/empty';
+
+type EmptyProjectsAction =
+  | { type: 'link'; href: string }
+  | { type: 'button'; onClick: () => void };
+
+interface EmptyProjectsProps {
+  action: EmptyProjectsAction;
+  className?: string;
+}
+
+export function EmptyProjects({ action, className }: EmptyProjectsProps) {
+  const t = useTranslations('projects');
+  const tDashboard = useTranslations('dashboard');
+
+  return (
+    <Empty className={cn('border', className)}>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <FolderPlus />
+        </EmptyMedia>
+        <EmptyTitle>{t('noProjects')}</EmptyTitle>
+        <EmptyDescription>{tDashboard('createFirstProject')}</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        {action.type === 'link' ? (
+          <Button asChild>
+            <Link href={action.href}>{t('new')}</Link>
+          </Button>
+        ) : (
+          <Button onClick={action.onClick}>{t('new')}</Button>
+        )}
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/web/shared/components/__tests__/EmptyProjects.test.tsx
+++ b/web/shared/components/__tests__/EmptyProjects.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EmptyProjects } from '@/shared/components/EmptyProjects';
+
+// Mock @/i18n/routing
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={`/en${href}`}>{children}</a>
+  ),
+}));
+
+const messages = {
+  projects: {
+    noProjects: 'No projects found',
+    new: 'New Project',
+  },
+  dashboard: {
+    createFirstProject: 'Create your first project to get started',
+  },
+};
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <NextIntlClientProvider locale="en" messages={messages}>
+        {children}
+      </NextIntlClientProvider>
+    );
+  };
+}
+
+describe('EmptyProjects', () => {
+  it('should render title and description', () => {
+    render(<EmptyProjects action={{ type: 'link', href: '/projects' }} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('No projects found')).toBeInTheDocument();
+    expect(
+      screen.getByText('Create your first project to get started')
+    ).toBeInTheDocument();
+  });
+
+  it('should render FolderPlus icon', () => {
+    const { container } = render(
+      <EmptyProjects action={{ type: 'link', href: '/projects' }} />,
+      { wrapper: createWrapper() }
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('should render as link when action type is link', () => {
+    render(<EmptyProjects action={{ type: 'link', href: '/projects' }} />, {
+      wrapper: createWrapper(),
+    });
+
+    const link = screen.getByRole('link', { name: 'New Project' });
+    expect(link).toHaveAttribute('href', '/en/projects');
+  });
+
+  it('should render as button when action type is button', () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyProjects action={{ type: 'button', onClick: handleClick }} />,
+      { wrapper: createWrapper() }
+    );
+
+    const button = screen.getByRole('button', { name: 'New Project' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should call onClick when button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <EmptyProjects action={{ type: 'button', onClick: handleClick }} />,
+      { wrapper: createWrapper() }
+    );
+
+    await user.click(screen.getByRole('button', { name: 'New Project' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <EmptyProjects
+        action={{ type: 'link', href: '/projects' }}
+        className="custom-class"
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    const emptyComponent = container.querySelector('[data-slot="empty"]');
+    expect(emptyComponent).toHaveClass('custom-class');
+  });
+});

--- a/web/shared/components/index.ts
+++ b/web/shared/components/index.ts
@@ -1,4 +1,5 @@
 export { BookmarkButton } from './BookmarkButton';
+export { EmptyProjects } from './EmptyProjects';
 export { ForbiddenPage } from './ForbiddenPage';
 export { LanguageSwitcher } from './LanguageSwitcher';
 export { NotFoundPage } from './NotFoundPage';


### PR DESCRIPTION
## Summary

- Unify "no projects" empty state UI between Dashboard and Projects pages
- Create `EmptyProjects` component in `shared/components/`
- Leverage existing `Empty` UI primitives (shadcn-based) internally

## Changes

| File | Change |
|------|--------|
| `web/shared/components/EmptyProjects.tsx` | **New** |
| `web/shared/components/index.ts` | Add export |
| `web/features/dashboard/components/RecentProjects.tsx` | `Card` based → `EmptyProjects` |
| `web/features/projects/components/ProjectList.tsx` | Plain text → `EmptyProjects`, add `onCreateClick` prop |
| `web/features/projects/components/ProjectsPageContent.tsx` | Pass `onCreateClick` to `ProjectList` |
| `web/shared/components/__tests__/EmptyProjects.test.tsx` | **New** |

## Before / After

**Dashboard (RecentProjects) - Before:**
Rich UI (icon, title, description, CTA button)

**Projects (ProjectList) - Before:**
Plain text only (`t('noProjects')`)

**After:**
Both use unified `EmptyProjects` component

## Test plan

- [ ] `pnpm run test:run` passes
- [ ] `/ja` (Dashboard) shows new UI when no projects exist
- [ ] `/ja/projects` shows same UI when no projects exist
- [ ] "New Project" button on Projects page opens create dialog

Closes #145