### PR TITLE
chore: share VSCode settings and recommended extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ Thumbs.db
 # IDE / Editor
 # ----------------------------------------
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 *.swp
 *.swo
 *.swn

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"biomejs.biome",
+		"charliermarsh.ruff",
+		"bradlc.vscode-tailwindcss",
+		"ms-python.python"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+	"biome.lsp.bin": "web/node_modules/@biomejs/biome/bin/biome",
+	"biome.configurationPath": "web",
+	"editor.codeActionsOnSave": {
+		"source.organizeImports.biome": "explicit"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.formatOnSave": true
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.formatOnSave": true
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.formatOnSave": true
+	},
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.formatOnSave": true
+	},
+	"[python]": {
+		"editor.defaultFormatter": "charliermarsh.ruff",
+		"editor.formatOnSave": true
+	}
+}


### PR DESCRIPTION
## Summary

Share project-level VSCode/Cursor configuration for consistent DX across contributors.

- Track `.vscode/settings.json` — Biome (JS/TS) and Ruff (Python) formatter/linter settings, including `biome.configurationPath` for monorepo support
- Add `.vscode/extensions.json` — recommended extensions (Biome, Ruff, Tailwind CSS IntelliSense, Python)
- Update `.gitignore` to selectively allow only these two files (`.vscode/*` + `!` exceptions)

## Test plan

- [x] Verify `.vscode/settings.json` and `.vscode/extensions.json` are tracked
- [x] Verify other `.vscode/` files remain ignored