### PR TITLE
chore(web): fix Biome nursery lint warnings

### DIFF
--- a/web/shared/components/BookmarkButton.tsx
+++ b/web/shared/components/BookmarkButton.tsx
@@ -88,7 +88,7 @@ export function BookmarkButton({
       aria-label={isBookmarked ? t('removeBookmark') : t('addBookmark')}
       className={cn(
         'transition-all duration-150',
-        isLoading && 'opacity-50 pointer-events-none',
+        isLoading && 'pointer-events-none opacity-50',
         isAnimating && 'animate-bookmark-pop',
         className
       )}
@@ -98,7 +98,7 @@ export function BookmarkButton({
           iconSize,
           'transition-colors duration-200',
           isBookmarked
-            ? 'fill-[var(--bookmark-active)] text-[var(--bookmark-active)]'
+            ? 'fill-(--bookmark-active) text-(--bookmark-active)'
             : 'text-muted-foreground hover:text-foreground'
         )}
         strokeWidth={isBookmarked ? 2 : 1.5}

--- a/web/shared/components/ProjectCard.tsx
+++ b/web/shared/components/ProjectCard.tsx
@@ -70,7 +70,7 @@ export function ProjectCard({
     <Card
       className={cn(
         'group rounded-md border-border/60 bg-card/80 shadow-none transition-all duration-200',
-        'hover:border-border hover:bg-card hover:shadow-sm py-1.5',
+        'py-1.5 hover:border-border hover:bg-card hover:shadow-sm',
         className
       )}
     >

--- a/web/shared/components/layout/ActivityBar.tsx
+++ b/web/shared/components/layout/ActivityBar.tsx
@@ -93,7 +93,7 @@ function ActivityBarItem({
           {/* Active indicator bar */}
           <span
             className={cn(
-              'absolute left-0 top-1/2 h-6 w-0.5 -translate-y-1/2 rounded-r-sm bg-activity-bar-indicator transition-opacity',
+              'absolute top-1/2 left-0 h-6 w-0.5 -translate-y-1/2 rounded-r-sm bg-activity-bar-indicator transition-opacity',
               isActive ? 'opacity-100' : 'opacity-0'
             )}
           />
@@ -104,7 +104,7 @@ function ActivityBarItem({
         side="right"
         sideOffset={8}
         hideArrow
-        className="border-0 bg-activity-bar-tooltip px-2 py-1 text-xs text-activity-bar-tooltip-foreground"
+        className="border-0 bg-activity-bar-tooltip px-2 py-1 text-activity-bar-tooltip-foreground text-xs"
       >
         {t(item.labelKey)}
       </TooltipContent>
@@ -141,7 +141,7 @@ function UserMenu({ locale }: { locale: string }) {
             >
               <Avatar size="default" className="cursor-pointer rounded-md">
                 <AvatarImage src={undefined} alt={user?.name || 'User'} />
-                <AvatarFallback className="bg-activity-bar-foreground text-activity-bar text-xs font-medium rounded-md">
+                <AvatarFallback className="rounded-md bg-activity-bar-foreground font-medium text-activity-bar text-xs">
                   {initials}
                 </AvatarFallback>
               </Avatar>
@@ -152,7 +152,7 @@ function UserMenu({ locale }: { locale: string }) {
           side="right"
           sideOffset={8}
           hideArrow
-          className="border-0 bg-activity-bar-tooltip px-2 py-1 text-xs text-activity-bar-tooltip-foreground"
+          className="border-0 bg-activity-bar-tooltip px-2 py-1 text-activity-bar-tooltip-foreground text-xs"
         >
           {tNav('account')}
         </TooltipContent>
@@ -163,7 +163,7 @@ function UserMenu({ locale }: { locale: string }) {
         sideOffset={12}
         className="w-64 border-activity-bar-border bg-activity-bar p-0"
       >
-        <div className="border-b border-activity-bar-border p-3">
+        <div className="border-activity-bar-border border-b p-3">
           <p className="truncate font-medium text-activity-bar-foreground-active text-sm">
             {user?.name || 'User'}
           </p>
@@ -200,7 +200,7 @@ export function ActivityBar() {
 
   return (
     <TooltipProvider delayDuration={200}>
-      <aside className="fixed left-0 top-0 z-50 flex h-screen w-12 flex-col border-r border-activity-bar-border bg-activity-bar select-none">
+      <aside className="fixed top-0 left-0 z-50 flex h-screen w-12 select-none flex-col border-activity-bar-border border-r bg-activity-bar">
         {/* Top navigation items */}
         <nav className="flex flex-1 flex-col items-center pt-3">
           {topNavItems.map((item) => (

--- a/web/shared/components/markdown/CodeBlock.tsx
+++ b/web/shared/components/markdown/CodeBlock.tsx
@@ -65,7 +65,7 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   // Block code with language label and copy button
   return (
     <>
-      <div className="flex items-center justify-between rounded-t-lg border-b border-white/10 bg-[#161b22] px-4 py-2 text-neutral-400 text-xs">
+      <div className="flex items-center justify-between rounded-t-lg border-white/10 border-b bg-[#161b22] px-4 py-2 text-neutral-400 text-xs">
         <span>{language}</span>
         <button
           type="button"

--- a/web/shared/components/markdown/MarkdownRenderer.tsx
+++ b/web/shared/components/markdown/MarkdownRenderer.tsx
@@ -42,7 +42,7 @@ export function MarkdownRenderer({
   return (
     <div
       className={cn(
-        'prose max-w-none dark:prose-invert',
+        'prose dark:prose-invert max-w-none',
         // Reset prose <pre> styles to avoid conflict with highlight.js
         'prose-pre:bg-transparent prose-pre:p-0',
         // Remove decorative backticks added by Typography plugin

--- a/web/shared/components/ui/avatar.tsx
+++ b/web/shared/components/ui/avatar.tsx
@@ -17,7 +17,7 @@ function Avatar({
       data-slot="avatar"
       data-size={size}
       className={cn(
-        'group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6',
+        'group/avatar relative flex size-8 shrink-0 select-none overflow-hidden rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6',
         className
       )}
       {...props}
@@ -46,7 +46,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs',
+        'flex size-full items-center justify-center rounded-full bg-muted text-muted-foreground text-sm group-data-[size=sm]/avatar:text-xs',
         className
       )}
       {...props}
@@ -59,7 +59,7 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<'span'>) {
     <span
       data-slot="avatar-badge"
       className={cn(
-        'bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full ring-2 select-none',
+        'absolute right-0 bottom-0 z-10 inline-flex select-none items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background',
         'group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden',
         'group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2',
         'group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2',
@@ -75,7 +75,7 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="avatar-group"
       className={cn(
-        '*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2',
+        'group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background',
         className
       )}
       {...props}
@@ -91,7 +91,7 @@ function AvatarGroupCount({
     <div
       data-slot="avatar-group-count"
       className={cn(
-        'bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
+        'relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground text-sm ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3',
         className
       )}
       {...props}

--- a/web/shared/components/ui/empty.tsx
+++ b/web/shared/components/ui/empty.tsx
@@ -7,7 +7,7 @@ function Empty({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty"
       className={cn(
-        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12',
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
         className
       )}
       {...props}
@@ -29,12 +29,12 @@ function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const emptyMediaVariants = cva(
-  'flex shrink-0 items-center justify-center mb-2 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {
         default: 'bg-transparent',
-        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
       },
     },
     defaultVariants: {
@@ -62,7 +62,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="empty-title"
-      className={cn('text-lg font-medium tracking-tight', className)}
+      className={cn('font-medium text-lg tracking-tight', className)}
       {...props}
     />
   );
@@ -73,7 +73,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
     <div
       data-slot="empty-description"
       className={cn(
-        'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
+        'text-muted-foreground text-sm/relaxed [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
         className
       )}
       {...props}
@@ -86,7 +86,7 @@ function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty-content"
       className={cn(
-        'flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance',
+        'flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm',
         className
       )}
       {...props}

--- a/web/shared/components/ui/popover.tsx
+++ b/web/shared/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in',
           className
         )}
         {...props}

--- a/web/shared/components/ui/radio-group.tsx
+++ b/web/shared/components/ui/radio-group.tsx
@@ -27,7 +27,7 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
         className
       )}
       {...props}
@@ -36,7 +36,7 @@ function RadioGroupItem({
         data-slot="radio-group-indicator"
         className="relative flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );

--- a/web/shared/components/ui/select.tsx
+++ b/web/shared/components/ui/select.tsx
@@ -76,7 +76,7 @@ function SelectContent({
           className={cn(
             'p-1',
             position === 'popper' &&
-              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
+              'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1'
           )}
         >
           {children}

--- a/web/shared/components/ui/tooltip.tsx
+++ b/web/shared/components/ui/tooltip.tsx
@@ -49,14 +49,14 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'fade-in-0 zoom-in-95 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in text-balance rounded-md bg-foreground px-3 py-1.5 text-background text-xs data-[state=closed]:animate-out',
           className
         )}
         {...props}
       >
         {children}
         {!hideArrow && (
-          <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
         )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
## Summary

Fix all 27 Biome nursery lint warnings across 11 files.

- **useSortedClasses**: Sort Tailwind CSS classes to match canonical order (e.g. `opacity-50 pointer-events-none` → `pointer-events-none opacity-50`)
- **suggestCanonicalClasses**: Use Tailwind v4 canonical CSS variable syntax (e.g. `fill-[var(--bookmark-active)]` → `fill-(--bookmark-active)`)

No functional changes — class order and syntax only.

## Test plan

- [x] `biome check` reports 0 warnings
- [x] All 192 tests pass