### PR TITLE
fix(web): add explicit text color to inline code for light mode

### DIFF
--- a/web/shared/components/markdown/CodeBlock.tsx
+++ b/web/shared/components/markdown/CodeBlock.tsx
@@ -52,7 +52,7 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
     return (
       <code
         className={cn(
-          'rounded bg-muted px-1.5 py-0.5 font-mono text-sm',
+          'rounded bg-muted px-1.5 py-0.5 font-mono text-foreground text-sm',
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

- Add `text-foreground` to inline code styling in `CodeBlock.tsx` to fix unreadable text in light mode

Closes #161

## Root Cause

`globals.css` imports `highlight.js/styles/github-dark.css` which sets light text colors globally. This cascaded into inline `<code>` elements, conflicting with the `bg-muted` background (light gray in light mode), making text nearly invisible.

## Test plan

- [x] `pnpm test` — CodeBlock tests pass
- [x] `pnpm check` — no lint errors
- [ ] Manual: verify inline code is readable in both light and dark mode