### PR TITLE
fix(web): use prepend anchor links for markdown headings

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -246,3 +246,4 @@ button, [role="button"] {
 .animate-bookmark-pop {
   animation: bookmark-pop 250ms ease-out;
 }
+

--- a/web/shared/components/markdown/MarkdownRenderer.tsx
+++ b/web/shared/components/markdown/MarkdownRenderer.tsx
@@ -47,6 +47,11 @@ export function MarkdownRenderer({
         'prose-pre:bg-transparent prose-pre:p-0',
         // Remove decorative backticks added by Typography plugin
         'prose-code:before:content-none prose-code:after:content-none',
+        // Heading anchor links: hidden by default, visible on heading hover
+        '[&_:is(h1,h2,h3,h4,h5,h6)]:relative',
+        '[&_.anchor-link]:absolute [&_.anchor-link]:right-full [&_.anchor-link]:pr-1 [&_.anchor-link]:opacity-0 [&_.anchor-link]:transition-opacity [&_.anchor-link]:duration-150',
+        '[&_.anchor-link]:font-normal [&_.anchor-link]:text-muted-foreground [&_.anchor-link]:no-underline',
+        '[&_:is(h1,h2,h3,h4,h5,h6):hover_.anchor-link]:opacity-70',
         className
       )}
     >
@@ -54,7 +59,18 @@ export function MarkdownRenderer({
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[
           rehypeSlug,
-          [rehypeAutolinkHeadings, { behavior: 'wrap' }],
+          [
+            rehypeAutolinkHeadings,
+            {
+              behavior: 'prepend',
+              properties: {
+                className: ['anchor-link'],
+                ariaHidden: true,
+                tabIndex: -1,
+              },
+              content: { type: 'text', value: '#' },
+            },
+          ],
           rehypeHighlight,
         ]}
         components={components}

--- a/web/shared/components/markdown/__tests__/MarkdownRenderer.test.tsx
+++ b/web/shared/components/markdown/__tests__/MarkdownRenderer.test.tsx
@@ -24,6 +24,16 @@ describe('MarkdownRenderer', () => {
 
     const heading = screen.getByRole('heading', { level: 2 });
     expect(heading).toHaveAttribute('id', 'my-heading');
+    expect(heading.textContent).toContain('My Heading');
+  });
+
+  it('should render anchor link before heading text', () => {
+    const { container } = render(<MarkdownRenderer content="## My Heading" />);
+
+    const anchorLink = container.querySelector('.anchor-link');
+    expect(anchorLink).toBeInTheDocument();
+    expect(anchorLink).toHaveAttribute('href', '#my-heading');
+    expect(anchorLink?.textContent).toBe('#');
   });
 
   it('should render GFM tables', () => {


### PR DESCRIPTION
## Summary
- Switch `rehypeAutolinkHeadings` from `behavior: 'wrap'` to `behavior: 'prepend'` to remove unwanted underline decoration on heading text
- Position `#` anchor icon outside the text flow using absolute positioning, visible only on heading hover
- Use Tailwind utility classes instead of custom CSS in globals.css (Tailwind v4 purges unreferenced custom CSS classes)

Closes #162

## Test plan
- [x] Unit tests pass (`pnpm test -- --run shared/components/markdown`)
- [x] Lint/format check passes (`pnpm check`)
- [x] Visual: heading text no longer has underline decoration
- [x] Visual: `#` anchor icon appears on heading hover
- [x] Clicking the anchor icon navigates to the heading URL