### PR TITLE
feat(web): add project activity page with timeline feed (#107)

### DIFF
--- a/web/app/[locale]/(main)/p/[projectSlug]/activity/page.tsx
+++ b/web/app/[locale]/(main)/p/[projectSlug]/activity/page.tsx
@@ -1,0 +1,25 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { setRequestLocale } from 'next-intl/server';
+
+import { ActivityPageContent } from '@/features/activity';
+import { prefetchActivity } from '@/features/activity/lib/prefetch';
+
+interface ActivityPageProps {
+  params: Promise<{
+    locale: string;
+    projectSlug: string;
+  }>;
+}
+
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  const { locale, projectSlug } = await params;
+  setRequestLocale(locale);
+
+  const queryClient = await prefetchActivity(projectSlug);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ActivityPageContent projectSlug={projectSlug} />
+    </HydrationBoundary>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -336,3 +336,20 @@ button, [role="button"] {
   animation: bookmark-pop 250ms ease-out;
 }
 
+/* Activity timeline animations */
+@keyframes activity-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-activity-fade-in {
+  opacity: 0;
+  animation: activity-fade-in 0.5s ease-out forwards;
+}
+

--- a/web/features/activity/components/ActivityChangeTypeBadge.tsx
+++ b/web/features/activity/components/ActivityChangeTypeBadge.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { Badge } from '@/shared/components/ui/badge';
+import { cn } from '@/shared/lib/utils';
+
+const changeTypeStyles: Record<string, string> = {
+  create:
+    'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  update: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
+  delete: 'border-destructive/30 bg-destructive/10 text-destructive',
+  rename:
+    'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+};
+
+interface ActivityChangeTypeBadgeProps {
+  changeType: string;
+}
+
+export function ActivityChangeTypeBadge({
+  changeType,
+}: ActivityChangeTypeBadgeProps) {
+  const t = useTranslations('activity.changeType');
+  const style = changeTypeStyles[changeType] ?? changeTypeStyles.update;
+  const label = ['create', 'update', 'delete', 'rename'].includes(changeType)
+    ? t(changeType as 'create' | 'update' | 'delete' | 'rename')
+    : changeType;
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn('px-1.5 py-0 font-normal text-[11px]', style)}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/web/features/activity/components/ActivityDocumentList.tsx
+++ b/web/features/activity/components/ActivityDocumentList.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { FileText } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import type { RevisionDocumentSummary } from '@/client/types.gen';
+
+import { ActivityChangeTypeBadge } from './ActivityChangeTypeBadge';
+
+const COLLAPSED_LIMIT = 3;
+
+interface ActivityDocumentListProps {
+  documents: RevisionDocumentSummary[];
+  projectSlug: string;
+}
+
+export function ActivityDocumentList({
+  documents,
+  projectSlug,
+}: ActivityDocumentListProps) {
+  const t = useTranslations('activity');
+  const params = useParams();
+  const locale = params.locale as string;
+  const [expanded, setExpanded] = useState(false);
+
+  if (documents.length === 0) return null;
+
+  const shouldCollapse = documents.length > COLLAPSED_LIMIT + 2;
+  const visibleDocs =
+    shouldCollapse && !expanded
+      ? documents.slice(0, COLLAPSED_LIMIT)
+      : documents;
+  const hiddenCount = documents.length - COLLAPSED_LIMIT;
+
+  return (
+    <div className="mt-2 ml-1 space-y-1 border-border border-l-2 pl-3">
+      {visibleDocs.map((doc) => (
+        <div key={doc.revision_id} className="flex items-center gap-2 text-sm">
+          <ActivityChangeTypeBadge changeType={doc.change_type} />
+          {doc.document_path && doc.change_type !== 'delete' ? (
+            <Link
+              href={`/${locale}/p/${projectSlug}/docs/${doc.document_path}`}
+              className="inline-flex items-center gap-1 truncate text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <FileText className="h-3 w-3 shrink-0" />
+              <span className="truncate">{doc.document_title}</span>
+            </Link>
+          ) : (
+            <span className="inline-flex items-center gap-1 truncate text-muted-foreground">
+              <FileText className="h-3 w-3 shrink-0" />
+              <span className="truncate">{doc.document_title}</span>
+            </span>
+          )}
+        </div>
+      ))}
+      {shouldCollapse && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="text-muted-foreground text-xs transition-colors hover:text-foreground"
+        >
+          {expanded ? t('showLess') : t('showMore', { count: hiddenCount })}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/features/activity/components/ActivityFeed.tsx
+++ b/web/features/activity/components/ActivityFeed.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { History } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/shared/components/ui/empty';
+
+import { useActivitySuspense } from '../hooks';
+import { ActivityFeedItem } from './ActivityFeedItem';
+
+interface ActivityFeedProps {
+  projectSlug: string;
+}
+
+export function ActivityFeed({ projectSlug }: ActivityFeedProps) {
+  const t = useTranslations('activity');
+  const { data: batches } = useActivitySuspense(projectSlug);
+
+  if (!batches || batches.length === 0) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <History />
+          </EmptyMedia>
+          <EmptyTitle>{t('empty.title')}</EmptyTitle>
+          <EmptyDescription>{t('empty.description')}</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {/* Timeline connector line */}
+      <div
+        className="absolute top-0 bottom-0 left-5 w-px bg-border"
+        aria-hidden="true"
+      />
+      <div className="space-y-0">
+        {batches.map((batch, index) => (
+          <ActivityFeedItem
+            key={batch.id}
+            batch={batch}
+            projectSlug={projectSlug}
+            index={index}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/features/activity/components/ActivityFeedItem.tsx
+++ b/web/features/activity/components/ActivityFeedItem.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { RevisionBatchRead } from '@/client/types.gen';
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from '@/shared/components/ui/avatar';
+
+import { ActivityDocumentList } from './ActivityDocumentList';
+
+interface ActivityFeedItemProps {
+  batch: RevisionBatchRead;
+  projectSlug: string;
+  index: number;
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatRelativeTime(dateStr: string, locale: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+  if (diffDay > 30) {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  }
+  if (diffDay > 0) return rtf.format(-diffDay, 'day');
+  if (diffHour > 0) return rtf.format(-diffHour, 'hour');
+  if (diffMin > 0) return rtf.format(-diffMin, 'minute');
+  return rtf.format(-diffSec, 'second');
+}
+
+export function ActivityFeedItem({
+  batch,
+  projectSlug,
+  index,
+}: ActivityFeedItemProps) {
+  const t = useTranslations('activity');
+  const userName = batch.user_name ?? t('unknownUser');
+  const locale =
+    typeof window !== 'undefined'
+      ? document.documentElement.lang || 'en'
+      : 'en';
+
+  return (
+    <div
+      className="animate-activity-fade-in relative pb-8 pl-12"
+      style={{ animationDelay: `${index * 60}ms` }}
+    >
+      {/* Timeline dot */}
+      <div className="absolute left-[15px] top-1.5 h-2.5 w-2.5 rounded-full border-2 border-background bg-muted-foreground" />
+
+      <div className="space-y-1.5">
+        {/* User info + timestamp */}
+        <div className="flex items-center gap-2.5">
+          <Avatar size="sm">
+            <AvatarImage
+              src={batch.user_avatar_url ?? undefined}
+              alt={userName}
+            />
+            <AvatarFallback className="text-[10px]">
+              {getInitials(userName)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="font-medium text-foreground text-sm">
+            {userName}
+          </span>
+          <span className="text-muted-foreground text-xs">
+            {formatRelativeTime(batch.created_at, locale)}
+          </span>
+        </div>
+
+        {/* Commit message */}
+        {batch.message && (
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            {batch.message}
+          </p>
+        )}
+
+        {/* Document changes */}
+        {batch.documents && batch.documents.length > 0 && (
+          <ActivityDocumentList
+            documents={batch.documents}
+            projectSlug={projectSlug}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/features/activity/components/ActivityFeedSkeleton.tsx
+++ b/web/features/activity/components/ActivityFeedSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/shared/components/ui/skeleton';
+
+export function ActivityFeedSkeleton() {
+  return (
+    <div className="relative">
+      {/* Timeline connector line */}
+      <div
+        className="absolute top-0 bottom-0 left-5 w-px bg-border"
+        aria-hidden="true"
+      />
+      <div className="space-y-0">
+        {Array.from({ length: 5 }, (_, i) => `skeleton-${i}`).map((id) => (
+          <div key={id} className="relative pb-8 pl-12">
+            {/* Timeline dot */}
+            <div className="absolute left-[15px] top-1.5 h-2.5 w-2.5 rounded-full bg-muted" />
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="h-4 w-48" />
+              <div className="ml-1 space-y-1.5 border-border border-l-2 pl-3">
+                <Skeleton className="h-3.5 w-40" />
+                <Skeleton className="h-3.5 w-36" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/features/activity/components/ActivityPageContent.tsx
+++ b/web/features/activity/components/ActivityPageContent.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { ActivityFeed } from './ActivityFeed';
+import { ActivityFeedSkeleton } from './ActivityFeedSkeleton';
+
+interface ActivityPageContentProps {
+  projectSlug: string;
+}
+
+function ActivityFeedError() {
+  const t = useTranslations('activity');
+  return <div className="py-8 text-center text-destructive">{t('error')}</div>;
+}
+
+export function ActivityPageContent({ projectSlug }: ActivityPageContentProps) {
+  const t = useTranslations('activity');
+
+  return (
+    <div className="space-y-6">
+      <h1 className="font-semibold text-2xl tracking-tight">{t('title')}</h1>
+      <ErrorBoundary fallback={<ActivityFeedError />}>
+        <Suspense fallback={<ActivityFeedSkeleton />}>
+          <ActivityFeed projectSlug={projectSlug} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/web/features/activity/components/__tests__/ActivityChangeTypeBadge.test.tsx
+++ b/web/features/activity/components/__tests__/ActivityChangeTypeBadge.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ActivityChangeTypeBadge } from '../ActivityChangeTypeBadge';
+
+const messages = {
+  activity: {
+    changeType: {
+      create: 'Created',
+      update: 'Updated',
+      delete: 'Deleted',
+      rename: 'Renamed',
+    },
+  },
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('ActivityChangeTypeBadge', () => {
+  it('renders "Created" for create change type', () => {
+    render(<ActivityChangeTypeBadge changeType="create" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText('Created')).toBeInTheDocument();
+  });
+
+  it('renders "Updated" for update change type', () => {
+    render(<ActivityChangeTypeBadge changeType="update" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText('Updated')).toBeInTheDocument();
+  });
+
+  it('renders "Deleted" for delete change type', () => {
+    render(<ActivityChangeTypeBadge changeType="delete" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+  });
+
+  it('renders "Renamed" for rename change type', () => {
+    render(<ActivityChangeTypeBadge changeType="rename" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText('Renamed')).toBeInTheDocument();
+  });
+
+  it('renders raw change type for unknown types', () => {
+    render(<ActivityChangeTypeBadge changeType="unknown_type" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText('unknown_type')).toBeInTheDocument();
+  });
+
+  it('applies green style for create', () => {
+    render(<ActivityChangeTypeBadge changeType="create" />, {
+      wrapper: Wrapper,
+    });
+    const badge = screen.getByText('Created');
+    expect(badge.className).toContain('emerald');
+  });
+
+  it('applies destructive style for delete', () => {
+    render(<ActivityChangeTypeBadge changeType="delete" />, {
+      wrapper: Wrapper,
+    });
+    const badge = screen.getByText('Deleted');
+    expect(badge.className).toContain('destructive');
+  });
+});

--- a/web/features/activity/components/__tests__/ActivityFeed.test.tsx
+++ b/web/features/activity/components/__tests__/ActivityFeed.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RevisionBatchRead } from '@/client/types.gen';
+
+import { ActivityFeed } from '../ActivityFeed';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'en', projectSlug: 'test-project' }),
+  usePathname: () => '/en/p/test-project/activity',
+}));
+
+const mockUseActivitySuspense = vi.fn();
+vi.mock('../../hooks', () => ({
+  useActivitySuspense: () => mockUseActivitySuspense(),
+}));
+
+const mockBatches: RevisionBatchRead[] = [
+  {
+    id: 'batch-1',
+    project_id: 'proj-1',
+    user_id: 'user-1',
+    user_name: 'John Doe',
+    user_avatar_url: null,
+    message: 'Updated API documentation',
+    created_at: '2026-01-28T12:00:00Z',
+    documents: [
+      {
+        revision_id: 'rev-1',
+        document_id: 'doc-1',
+        change_type: 'update',
+        document_title: 'Getting Started',
+        document_path: 'getting-started',
+      },
+      {
+        revision_id: 'rev-2',
+        document_id: 'doc-2',
+        change_type: 'create',
+        document_title: 'API Reference',
+        document_path: 'api-reference',
+      },
+    ],
+  },
+  {
+    id: 'batch-2',
+    project_id: 'proj-1',
+    user_id: 'user-2',
+    user_name: 'Jane Smith',
+    user_avatar_url: null,
+    message: 'Initial setup',
+    created_at: '2026-01-27T10:00:00Z',
+    documents: [
+      {
+        revision_id: 'rev-3',
+        document_id: 'doc-3',
+        change_type: 'create',
+        document_title: 'Introduction',
+        document_path: 'introduction',
+      },
+    ],
+  },
+];
+
+const messages = {
+  activity: {
+    title: 'Activity',
+    empty: {
+      title: 'No activity yet',
+      description: 'Changes to documents in this project will appear here.',
+    },
+    error: 'Failed to load activity',
+    changeType: {
+      create: 'Created',
+      update: 'Updated',
+      delete: 'Deleted',
+      rename: 'Renamed',
+    },
+    showMore: 'Show {count} more',
+    showLess: 'Show less',
+    unknownUser: 'Unknown user',
+    documentsChanged: '{count} documents changed',
+  },
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <NextIntlClientProvider locale="en" messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('ActivityFeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders empty state when no activity', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: [] });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('No activity yet')).toBeInTheDocument();
+    expect(
+      screen.getByText('Changes to documents in this project will appear here.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders feed items with user names', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: mockBatches });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+  });
+
+  it('renders commit messages', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: mockBatches });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('Updated API documentation')).toBeInTheDocument();
+    expect(screen.getByText('Initial setup')).toBeInTheDocument();
+  });
+
+  it('renders document titles', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: mockBatches });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('Getting Started')).toBeInTheDocument();
+    expect(screen.getByText('API Reference')).toBeInTheDocument();
+    expect(screen.getByText('Introduction')).toBeInTheDocument();
+  });
+
+  it('renders document links with correct paths', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: mockBatches });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute(
+      'href',
+      '/en/p/test-project/docs/getting-started'
+    );
+    expect(links[1]).toHaveAttribute(
+      'href',
+      '/en/p/test-project/docs/api-reference'
+    );
+  });
+
+  it('renders change type badges', () => {
+    mockUseActivitySuspense.mockReturnValue({ data: mockBatches });
+
+    render(<ActivityFeed projectSlug="test-project" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getAllByText('Created')).toHaveLength(2);
+    expect(screen.getByText('Updated')).toBeInTheDocument();
+  });
+});

--- a/web/features/activity/components/__tests__/ActivityFeedItem.test.tsx
+++ b/web/features/activity/components/__tests__/ActivityFeedItem.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RevisionBatchRead } from '@/client/types.gen';
+
+import { ActivityFeedItem } from '../ActivityFeedItem';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'en', projectSlug: 'test-project' }),
+}));
+
+const messages = {
+  activity: {
+    changeType: {
+      create: 'Created',
+      update: 'Updated',
+      delete: 'Deleted',
+      rename: 'Renamed',
+    },
+    showMore: 'Show {count} more',
+    showLess: 'Show less',
+    unknownUser: 'Unknown user',
+    documentsChanged: '{count} documents changed',
+  },
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+
+function createBatch(
+  overrides: Partial<RevisionBatchRead> = {}
+): RevisionBatchRead {
+  return {
+    id: 'batch-1',
+    project_id: 'proj-1',
+    user_id: 'user-1',
+    user_name: 'John Doe',
+    user_avatar_url: null,
+    message: 'Updated docs',
+    created_at: new Date().toISOString(),
+    documents: [
+      {
+        revision_id: 'rev-1',
+        document_id: 'doc-1',
+        change_type: 'update',
+        document_title: 'Getting Started',
+        document_path: 'getting-started',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('ActivityFeedItem', () => {
+  it('renders user name', () => {
+    render(
+      <ActivityFeedItem
+        batch={createBatch()}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('renders "Unknown user" when user_name is null', () => {
+    render(
+      <ActivityFeedItem
+        batch={createBatch({ user_name: null })}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText('Unknown user')).toBeInTheDocument();
+  });
+
+  it('renders user initials in avatar fallback', () => {
+    render(
+      <ActivityFeedItem
+        batch={createBatch()}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders commit message', () => {
+    render(
+      <ActivityFeedItem
+        batch={createBatch()}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText('Updated docs')).toBeInTheDocument();
+  });
+
+  it('does not render message when null', () => {
+    render(
+      <ActivityFeedItem
+        batch={createBatch({ message: null })}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByText('Updated docs')).not.toBeInTheDocument();
+  });
+
+  it('applies staggered animation delay based on index', () => {
+    const { container } = render(
+      <ActivityFeedItem
+        batch={createBatch()}
+        projectSlug="test-project"
+        index={3}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const item = container.firstChild as HTMLElement;
+    expect(item.style.animationDelay).toBe('180ms');
+  });
+
+  it('shows "Show more" toggle when documents exceed limit', async () => {
+    const manyDocs = Array.from({ length: 8 }, (_, i) => ({
+      revision_id: `rev-${i}`,
+      document_id: `doc-${i}`,
+      change_type: 'update',
+      document_title: `Document ${i}`,
+      document_path: `doc-${i}`,
+    }));
+
+    render(
+      <ActivityFeedItem
+        batch={createBatch({ documents: manyDocs })}
+        projectSlug="test-project"
+        index={0}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    // Only first 3 shown by default
+    expect(screen.getByText('Document 0')).toBeInTheDocument();
+    expect(screen.getByText('Document 1')).toBeInTheDocument();
+    expect(screen.getByText('Document 2')).toBeInTheDocument();
+    expect(screen.queryByText('Document 3')).not.toBeInTheDocument();
+
+    // Toggle to show all
+    const showMoreBtn = screen.getByText('Show 5 more');
+    await userEvent.click(showMoreBtn);
+
+    expect(screen.getByText('Document 7')).toBeInTheDocument();
+    expect(screen.getByText('Show less')).toBeInTheDocument();
+  });
+
+  it('does not render link for deleted documents', () => {
+    const batch = createBatch({
+      documents: [
+        {
+          revision_id: 'rev-1',
+          document_id: 'doc-1',
+          change_type: 'delete',
+          document_title: 'Deleted Page',
+          document_path: 'deleted-page',
+        },
+      ],
+    });
+
+    render(
+      <ActivityFeedItem batch={batch} projectSlug="test-project" index={0} />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText('Deleted Page')).toBeInTheDocument();
+    // The deleted document should not be a link
+    const links = screen.queryAllByRole('link');
+    const deletedLink = links.find((link) =>
+      link.textContent?.includes('Deleted Page')
+    );
+    expect(deletedLink).toBeUndefined();
+  });
+});

--- a/web/features/activity/components/index.ts
+++ b/web/features/activity/components/index.ts
@@ -1,0 +1,6 @@
+export { ActivityChangeTypeBadge } from './ActivityChangeTypeBadge';
+export { ActivityDocumentList } from './ActivityDocumentList';
+export { ActivityFeed } from './ActivityFeed';
+export { ActivityFeedItem } from './ActivityFeedItem';
+export { ActivityFeedSkeleton } from './ActivityFeedSkeleton';
+export { ActivityPageContent } from './ActivityPageContent';

--- a/web/features/activity/hooks/index.ts
+++ b/web/features/activity/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useActivitySuspense } from './useActivity';

--- a/web/features/activity/hooks/useActivity.ts
+++ b/web/features/activity/hooks/useActivity.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getProjectActivityOptions } from '@/client/@tanstack/react-query.gen';
+
+/**
+ * Suspense-enabled hook for fetching project activity feed.
+ * Use with React Suspense and server-side prefetching via HydrationBoundary.
+ *
+ * @param slug - Project slug
+ * @param skip - Number of records to skip (pagination)
+ * @param limit - Maximum number of records to return
+ */
+export function useActivitySuspense(slug: string, skip = 0, limit = 50) {
+  return useSuspenseQuery(
+    getProjectActivityOptions({ path: { slug }, query: { skip, limit } })
+  );
+}

--- a/web/features/activity/index.ts
+++ b/web/features/activity/index.ts
@@ -1,0 +1,2 @@
+export * from './components';
+export * from './hooks';

--- a/web/features/activity/lib/prefetch.ts
+++ b/web/features/activity/lib/prefetch.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-side prefetch utilities for activity feed.
+ * Use these in Server Components to prefetch data before rendering.
+ */
+import { QueryClient } from '@tanstack/react-query';
+
+import { Documents } from '@/client';
+import { getProjectActivityOptions } from '@/client/@tanstack/react-query.gen';
+import { getServerClient } from '@/shared/lib/api/client';
+
+/**
+ * Prefetch project activity feed on the server.
+ * Returns a QueryClient with the prefetched data.
+ */
+export async function prefetchActivity(
+  slug: string,
+  skip = 0,
+  limit = 50
+): Promise<QueryClient> {
+  const queryClient = new QueryClient();
+  const client = getServerClient();
+
+  await queryClient.prefetchQuery({
+    ...getProjectActivityOptions({ path: { slug }, query: { skip, limit } }),
+    queryFn: async () => {
+      const { data } = await Documents.getProjectActivity({
+        client,
+        path: { slug },
+        query: { skip, limit },
+        throwOnError: true,
+      });
+      return data;
+    },
+  });
+
+  return queryClient;
+}

--- a/web/features/projects/components/ProjectTabs.tsx
+++ b/web/features/projects/components/ProjectTabs.tsx
@@ -2,6 +2,7 @@
 
 import {
   FileText,
+  History,
   type LucideIcon,
   MessageSquare,
   Pencil,
@@ -55,6 +56,12 @@ export function ProjectTabs() {
       href: `${basePath}/chat`,
       icon: MessageSquare,
       labelKey: 'projectTabs.chat',
+    },
+    {
+      key: 'activity',
+      href: `${basePath}/activity`,
+      icon: History,
+      labelKey: 'projectTabs.activity',
     },
     {
       key: 'settings',

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -214,7 +214,26 @@
     "docs": "Docs",
     "edit": "Edit",
     "chat": "Chat",
+    "activity": "Activity",
     "settings": "Settings"
+  },
+  "activity": {
+    "title": "Activity",
+    "empty": {
+      "title": "No activity yet",
+      "description": "Changes to documents in this project will appear here."
+    },
+    "error": "Failed to load activity",
+    "changeType": {
+      "create": "Created",
+      "update": "Updated",
+      "delete": "Deleted",
+      "rename": "Renamed"
+    },
+    "showMore": "Show {count} more",
+    "showLess": "Show less",
+    "unknownUser": "Unknown user",
+    "documentsChanged": "{count} {count, plural, one {document} other {documents}} changed"
   },
   "setup": {
     "title": "Initial Setup",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -214,7 +214,26 @@
     "docs": "ドキュメント",
     "edit": "編集",
     "chat": "チャット",
+    "activity": "アクティビティ",
     "settings": "設定"
+  },
+  "activity": {
+    "title": "アクティビティ",
+    "empty": {
+      "title": "アクティビティがありません",
+      "description": "このプロジェクトのドキュメントの変更がここに表示されます。"
+    },
+    "error": "アクティビティの読み込みに失敗しました",
+    "changeType": {
+      "create": "作成",
+      "update": "更新",
+      "delete": "削除",
+      "rename": "名前変更"
+    },
+    "showMore": "さらに{count}件表示",
+    "showLess": "折りたたむ",
+    "unknownUser": "不明なユーザー",
+    "documentsChanged": "{count}件のドキュメントが変更されました"
   },
   "setup": {
     "title": "初期セットアップ",


### PR DESCRIPTION
## Summary

- Implement `/{locale}/p/{projectSlug}/activity` page displaying revision history as a timeline feed
- Add `features/activity/` feature module with ActivityFeed, ActivityFeedItem, ActivityDocumentList, and ActivityChangeTypeBadge components
- Add "Activity" tab to ProjectTabs (between Chat and Settings)
- Each revision batch shows user avatar, name, relative timestamp, commit message, and expandable document changes with color-coded change type badges (Created/Updated/Deleted/Renamed)
- Staggered fade-in animation on the timeline for visual polish

## Test plan

- [x] Lint passes (`pnpm run check` — 0 errors)
- [x] All 314 tests pass (`pnpm run test:run`)
- [x] Build succeeds (`pnpm run build` — activity route recognized)
- [ ] Manual: Navigate to a project's Activity tab and verify the timeline renders
- [ ] Manual: Verify empty state shows when project has no activity
- [ ] Manual: Verify document links navigate correctly
- [ ] Manual: Verify "Show more" toggle works with >5 documents in a batch

Closes #107